### PR TITLE
Scipy Stack specification

### DIFF
--- a/www/install.rst
+++ b/www/install.rst
@@ -41,7 +41,7 @@ Custom
 ------
 
 You can assemble the Scipy stack from individual packages. For details of what
-you need, see the specification. Packages are typically on `the Python Package
+you need, see :ref:`the specification <stackspec>`. Packages are typically on `the Python Package
 Index <http://pypi.python.org/pypi/>`_, and projects' sites may also offer
 official binary packages (e.g. `numpy <http://sourceforge.net/projects/numpy/files/NumPy/>`_,
 `scipy library <http://sourceforge.net/projects/scipy/files/scipy/>`_).

--- a/www/stackspec.rst
+++ b/www/stackspec.rst
@@ -1,3 +1,5 @@
+.. _stackspec:
+
 =============================
 The Scipy Stack specification
 =============================


### PR DESCRIPTION
This adds a page for the Scipy Stack specification. It's not yet in any menus, although it's linked from the installation page.
