### PR TITLE
Add info for Mac package managers

### DIFF
--- a/www/install.rst
+++ b/www/install.rst
@@ -37,6 +37,23 @@ The versions in Ubuntu 12.10 and Debian 7.0 meet the current Scipy stack
 specification. Users might also want to add the `NeuroDebian repository
 <http://neuro.debian.net/>`_ for extra Scipy packages.
 
+Mac packages
+--------------
+
+Macs (unlike Linux) don't come with a package manager, but you can install a package manager and then use it to install the scipy stack.
+The most popular Mac package managers are:
+
+* `Macports <http://www.macports.org>`_
+* `Homebrew <http://mxcl.github.com/homebrew/>`_
+* `Fink <http://www.finkproject.org>`_
+
+To install the scipy stack for Python 2.7 with Macports execute this command in a terminal:
+
+::
+
+    sudo port install py27-numpy py27-scipy py27-matplotlib py27-ipython +notebook py27-pandas py27-sympy py27-nose
+
+
 Custom
 ------
 


### PR DESCRIPTION
For now I've added the command to install the scipy stack with Macports.

I think there should be a sub-page install-mac.rst that describes some details for MacPorts, Homebrew and Fink. I'm not a Fink and Homebrew user, but I can try it out and write detailed instructions for those also if you think it's useful.

E.g. for Macports it's good to know that the Macports installer adds this to .profile:

```
export PATH=/opt/local/bin:/opt/local/sbin:$PATH
```

Also users will probably want to run these commands for the packages that install command line tools to get symlinks with the usual names (i.e. without version numbers in the names):

```
sudo port select --set python python27
sudo port select --set ipython ipython27
sudo port select py-sympy py27-sympy
sudo port select nosetests nosetests27
```

And very soon when maplotlib 1.2 is out the scipy stack will be available for 3.2 if the user wants, so that should be described.
