### PR TITLE
updated link and text about Anaconda

### DIFF
--- a/www/install.rst
+++ b/www/install.rst
@@ -9,9 +9,8 @@ For most users, especially on Windows and Mac, the easiest way to install the
 packages of the Scipy stack is to download one of these Python distributions,
 which includes all the key packages:
 
-* `Anaconda <https://store.continuum.io/cshop/anaconda>`_: Both the free and the
-  commercial versions include the core Scipy stack. Supports Linux, Windows and
-  Mac.
+* `Anaconda <http://continuum.io/downloads.html>`_: A free distribution
+  for the Scipy stack. Supports Linux, Windows and Mac.
 * `Enthought Canopy <http://www.enthought.com/products/canopy/>`_: The free and
   commercial versions include the core Scipy stack packages. Supports Linux,
   Windows and Mac.


### PR DESCRIPTION
In March this year, Anaconda became a completely free distribution, i.e. there is no longer a commercial version of Anaconda.  This PR reflects this change and also updates the download link to a page where Anaconda can be downloaded without providing an email address.
