### PR TITLE
DOC: add Cython as build dependency for SciPy

### DIFF
--- a/www/scipylib/building/linux.rst
+++ b/www/scipylib/building/linux.rst
@@ -31,6 +31,11 @@ Before building, you will also need to install packages that Numpy and Scipy dep
 
 * Python header files (typically a package named ``python-dev`` or ``python-devel``)
 
+* the `Cython <http://cython.org/>`__ compiler to create ``c`` files
+  (typically in a package named ``cython``). For building recent SciPy,
+  it is possible that you need Cython in a newer version than is
+  available in your distribution.
+
 Typically, you will want to install all of the above from packages supplied by your Linux distribution, as building them yourself is complicated. If you need to use specific BLAS/LAPACK libraries, you can do
 
 ::

--- a/www/scipylib/building/macosx.rst
+++ b/www/scipylib/building/macosx.rst
@@ -29,8 +29,8 @@ components are installed by choosing **customize** when available during the
 install process and selecting all optional packages - at least the X11
 development tools and (on OS X 10.6 or lower) the 10.4 SDK.
 
-FORTRAN
--------
+Compilers (C/C++/FORTRAN/Cython)
+--------------------------------
 
 Though virtually any commercial C/C++ compiler may be used with SciPy, OS X
 comes with GNU C compilers pre-installed. The only thing missing is the GNU
@@ -46,6 +46,9 @@ use the following binaries:
   4.2 or higher) (also available through Homebrew)
 
 See `this site <http://r.research.att.com/tools/>`__ for the most recent links.
+
+Additionally, a recent version of the `Cython <http://cython.org/>`__
+compiler is needed to create ``c`` files.
 
 Version-specific notes
 ----------------------

--- a/www/scipylib/building/windows.rst
+++ b/www/scipylib/building/windows.rst
@@ -43,7 +43,9 @@ Downloading and installing a compiler
 -------------------------------------
 
 Generally you only need one C compiler (and one Fortran compiler). Cygwin is
-required if you want to build ATLAS yourself.
+required if you want to build ATLAS yourself. Additionally, you need a
+recent version of the `Cython <http://cython.org/>`__ compiler to create
+``c`` files.
 
 MinGW
 #####


### PR DESCRIPTION
In the build documentation, mention the Cython dependency for building from source.
