### PR TITLE
DOC: clang++ for c++ on OSX

### DIFF
--- a/www/scipylib/building/macosx.rst
+++ b/www/scipylib/building/macosx.rst
@@ -84,7 +84,7 @@ gcc, the easiest thing is to do:
 ::
 
      $ export CC=clang
-     $ export CXX=clang
+     $ export CXX=clang++
      $ export FFLAGS=-ff2c
 
 Alternatively, you may try installing gcc-4.2 manually, and then using


### PR DESCRIPTION
clang++ needed for scipy sparse compile on OSX 10.9 and Xcode 5.0.2 at least.
