### PR TITLE
Added links to "topical software" page

### DIFF
--- a/www/topical-software.rst
+++ b/www/topical-software.rst
@@ -462,7 +462,7 @@ Quantum mechanics
 -----------------
 
 - `QuTiP <http://www.qutip.org/>`__ QuTiP is a numerical framework for simulating the dynamics of open and closed quantum systems. 
-- `QNET <http://mabuchilab.github.io/QNET/>`__ The QNET is a package to aid in the design and analysis of photonic circuit models.
+- `QNET <http://mabuchilab.github.io/QNET/>`__ QNET is a package to aid in the design and analysis of photonic circuit models.
 - `PyQuante <http://pyquante.sourceforge.net/>`__ PyQuante is a suite of programs for developing quantum chemistry methods.
 
 Miscellaneous


### PR DESCRIPTION
Adding links to a set of IPython notebooks on scientific computing with python to the tutorials sections, and links to three quantum mechanics packages in a new subsection "Quantum mechanics" under the section "Topic guides, organized by scientific field".
