### PR TITLE
Update list of links to Python and Scipy (stack) lectures.

### DIFF
--- a/www/topical-software.rst
+++ b/www/topical-software.rst
@@ -58,28 +58,29 @@ General Python resources
 Tutorials and texts
 ===================
 
-Some generic Python/programming tutorials:
-------------------------------------------
+Generic Python/programming tutorials:
+-------------------------------------
 
 - `The standard Python docs <http://www.python.org/doc/>`__ : this contains the official documentation and tutorials which ship with the language.
-- `Learning to Program <http://www.freenetpages.co.uk/hp/alan.gauld/>`__: beginner's tutorial.
-- `How to Think Like a Computer Scientist <http://www.greenteapress.com/thinkpython/thinkCSpy/>`__: another beginner's tutorial.
-- `Many more <http://www.awaretek.com/tutorials.html>`__: an external collection with over 100 tutorials.
+- `Learn Python <learnpython.org>`__ Interactive site with Python tutorials.
+- `How to Think Like a Computer Scientist <http://www.greenteapress.com/thinkpython/thinkCSpy/>`__: a free book for Python beginners.
 
-And some more specifically geared towards scientific computing:
----------------------------------------------------------------
+Scientific computing with Python tutorials:
+-------------------------------------------
 
 - The main `NumPy and SciPy documentation <http://docs.scipy.org/>`__.
-- The `extra documentation page <http://wiki.scipy.org/Additional_Documentation/>`__ has a number of important links on using SciPy, including a (slightly outdated, but still useful) `PDF tutorial <http://wiki.scipy.org/Additional_Documentation?action=AttachFile&do=get&target=scipy_tutorial.pdf>`__ for the SciPy library.
-- The `user guide for the new NumPy system <http://www.tramy.us/>`__. Numeric and Numarray have been unified into the new NumPy environment. This document covers all the details of the new system, and was written by its lead developer.
-- A `tutorial focused on interactive data analysis <http://wiki.scipy.org/Additional_Documentation/Astronomy_Tutorial>`__ for astronomy, but of generic utility to most scientific users. Developed at the STSCI, available for free download including all data files necessary to run the examples.
-- `Konrad Hinsen's Python page <http://starship.python.net/crew/hinsen/>`__: contains a number of introductions and tutorials to Python, geared towards the needs of scientists.
-- `Jacek Generowicz's Python Courses. <http://jacek.home.cern.ch/jacek/python-course>`__
-- `Python Scripting for Computational Science <http://www.springeronline.com/sgw/cda/frontpage/0,11855,5-115-22-17627636-0,00.html>`__: not free, this is a Springer book.
-- `Python/Matlab/Octave/Scilab/R/Gnuplot/IDL/Axiom <http://mathesaurus.sourceforge.net>`__ cross-reference by Vidar Gundersen.
+- `Python Scientific Lecture Notes <http://scipy-lectures.github.io/>`__ a comprehensive set of tutorials on the scientific Python ecosystem. 
 - `Software Carpentry <http://software-carpentry.org/>`__ is an open source course on basic software development skills for people with backgrounds in science, engineering, and medicine.
-- `A tutorial for SciPy <http://www.rexx.com/~dkuhlman/scipy_course_01.html>`__ by Dave Kuhlman ( dkuhlman@rexx.com ).
 - `Lectures on scientific computing with Python <https://github.com/jrjohansson/scientific-python-lectures>`__ by J.R. Johansson.
+
+Older scientific computing tutorials:
+-------------------------------------
+
+- The `extra documentation page <http://wiki.scipy.org/Additional_Documentation/>`__ has a number of important links on using SciPy, including a (slightly outdated, but still useful) `PDF tutorial <http://wiki.scipy.org/Additional_Documentation?action=AttachFile&do=get&target=scipy_tutorial.pdf>`__ for the SciPy library.
+- `A tutorial for SciPy <http://www.rexx.com/~dkuhlman/scipy_course_01.html>`__ by Dave Kuhlman. 
+- `Python Scripting for Computational Science <http://www.springer.com/mathematics/computational+science+%26+engineering/book/978-3-540-73915-9>`__: not free, this is a Springer book.
+- `Python/Matlab/Octave/Scilab/R/Gnuplot/IDL/Axiom <http://mathesaurus.sourceforge.net>`__ cross-reference by Vidar Gundersen.
+- A `tutorial focused on interactive data analysis <http://wiki.scipy.org/Additional_Documentation/Astronomy_Tutorial>`__ for astronomy, but of generic utility to most scientific users. Developed at the STSCI, available for free download including all data files necessary to run the examples.
 
 Working environments
 ====================


### PR DESCRIPTION
Removes broken links and links to sites I deemed inappropriate (due to bad/outdated content or being too commercial in nature).

Add links to Scipy Lecture Notes and Learn Python site.
