### PR TITLE
Update citations page

### DIFF
--- a/www/scipylib/citing.rst
+++ b/www/scipylib/citing.rst
@@ -133,7 +133,7 @@ scikit-image
 
 * Stéfan van der Walt, Johannes L. Schönberger, Juan Nunez-Inglesias, François
   Boulogne, Joshua D. Warner, Neil Yager, Emmanuelle Gouillart, Tony Yu and the
-  scikit-image contributor.
+  scikit-image contributors.
   **scikit-image: Image processing in Python**,
   PeerJ PrePrints, 2:e336v2 (2012)
   (`publisher link`__)


### PR DESCRIPTION
After [this post](http://scipy-user.10969.n7.nabble.com/SciPy-User-How-do-I-cite-SciPy-and-NumPy-when-I-used-them-for-a-paper-td18708.html) on the SciPy list I've spent some time cleaning up our citations page.
