### PR TITLE
MAINT: clarify the status of the scipy sourceforge page

### DIFF
--- a/www/scipylib/download.rst
+++ b/www/scipylib/download.rst
@@ -29,6 +29,7 @@ vendor.
 |        |  (all platforms) and         | `SciPy release page`_               |
 | SciPy  |  *binaries* for **Windows**  |                                     |
 |        |  & **Mac OS X**              | `SourceForge site for SciPy`_       |
+|        |                              |  (legacy releases only)             |
 |        |                              |                                     |
 +--------+------------------------------+-------------------------------------+
 


### PR DESCRIPTION
Orion Poplawski on ML, https://mail.scipy.org/pipermail/scipy-dev/2016-February/021233.html

> I'll note that 
> http://www.scipy.org/scipylib/download.html#official-source-and-binary-releases 
> still points to the sourceforge site which does not appear to be updated.

