### PR TITLE
DOC: added link to paramnormal in topical software

### DIFF
--- a/www/topical-software.rst
+++ b/www/topical-software.rst
@@ -120,6 +120,7 @@ These are links which cover basic tools generally useful for scientific work in 
 - `KryPy <https://github.com/andrenarchy/krypy>`__ is a Krylov subspace methods package for the efficient solution of linear algebraic systems with large and sparse matrices.
 - `Imageio <http://imageio.github.io/>`__ is a library that provides an easy interface to read and write a wide range of image data, including animated images, video, volumetric data, and scientific formats. It is cross-platform, runs on Python 2.x and 3.x, and is easy to install.
 - `mpmath <http://mpmath.org/>`__ is a free (BSD licensed) Python library for real and complex floating-point arithmetic with arbitrary precision.
+ - `paramnormal <http://phobson.github.io/paramnormal/>`__ is a wrapper around the ``scipy.stats`` module that facilitates creating, fitting, and vizualizing probability distributions with more conventional parameters. 
 
 
 Running Code Written In Other Languages


### PR DESCRIPTION
Just a minor change to include a link to my paramnormal package as suggested by @ev-br:

https://github.com/phobson/paramnormal/issues/32#issuecomment-193934691