### PR TITLE
Add BLAS/LAPACK to Fedora installation. Fixes #159

### DIFF
--- a/www/citing.rst
+++ b/www/citing.rst
@@ -137,7 +137,7 @@ __ http://jmlr.org/papers/v12/pedregosa11a.html
 scikit-image
 ############
 
-* Stéfan van der Walt, Johannes L. Schönberger, Juan Nunez-Inglesias, François
+* Stéfan van der Walt, Johannes L. Schönberger, Juan Nunez-Iglesias, François
   Boulogne, Joshua D. Warner, Neil Yager, Emmanuelle Gouillart, Tony Yu and the
   scikit-image contributors.
   **scikit-image: Image processing in Python**,

--- a/www/index.rst
+++ b/www/index.rst
@@ -214,6 +214,9 @@ News
 .. role:: news-date
    :class: news-date
 
+SciPy 0.17.1 released :news-date:`2016-05-12`
+    See :doc:`/scipylib/download`.
+
 NumPy 1.11.0 released :news-date:`2016-03-27`
     See :doc:`/scipylib/download`.
 

--- a/www/index.rst
+++ b/www/index.rst
@@ -214,7 +214,7 @@ News
 .. role:: news-date
    :class: news-date
 
-NumPy 1.11.0rc2 released :news-date:`2016-03-19`
+NumPy 1.11.0 released :news-date:`2016-03-27`
     See :doc:`/scipylib/download`.
 
 SciPy 0.17.0 released :news-date:`2016-01-23`

--- a/www/index.rst
+++ b/www/index.rst
@@ -214,6 +214,9 @@ News
 .. role:: news-date
    :class: news-date
 
+NumPy 1.11.1rc1 released :news-date:`2016-05-26`
+    See :doc:`/scipylib/download`.
+
 SciPy 0.17.1 released :news-date:`2016-05-12`
     See :doc:`/scipylib/download`.
 

--- a/www/install.rst
+++ b/www/install.rst
@@ -38,8 +38,8 @@ Ubuntu & Debian
 
     sudo apt-get install python-numpy python-scipy python-matplotlib ipython ipython-notebook python-pandas python-sympy python-nose
 
-The versions in Ubuntu 12.10 and Debian 7.0 meet the current SciPy stack
-specification. Users might also want to add the `NeuroDebian repository
+The versions in Ubuntu 12.10 or newer and Debian 7.0 or newer meet the current
+SciPy stack specification. Users might also want to add the `NeuroDebian repository
 <http://neuro.debian.net/>`_ for extra SciPy packages.
 
 Fedora
@@ -49,9 +49,7 @@ Fedora
 
     sudo yum install numpy scipy python-matplotlib ipython python-pandas sympy python-nose blas-devel lapack-devel
 
-Users of Fedora 17 and earlier should then upgrade IPython using pip::
-
-    sudo pip install --upgrade ipython
+The versions in Fedora 17 or newer meet the current SciPy stack specification.
 
 Gentoo
 ~~~~~~
@@ -62,9 +60,7 @@ Gentoo
 
 You may get some messages saying that keyword changes or USE changes are
 necessary in order to proceed, and that you should use ``--autounmask-write`` to
-write changes to config files. This is especially likely to happen if you are
-running Gentoo Stable rather than Gentoo Testing, as of this writing (February
-2013).
+write changes to config files.
 
 If this happens, just run the above command with ``--autounmask-write``
 appended, then run ``sudo dispatch-conf`` (or an alternative) to save the
@@ -79,13 +75,27 @@ popular package managers you can install.
 Macports
 ~~~~~~~~
 
-To install the scipy stack for Python 2.7 with `Macports
+To install the SciPy stack for Python 2.7 with `Macports
 <http://www.macports.org>`_ execute this command in a terminal::
 
     sudo port install py27-numpy py27-scipy py27-matplotlib py27-ipython +notebook py27-pandas py27-sympy py27-nose
 
+Homebrew
+~~~~~~~~
+
+At the time of writing (March 2016), `Homebrew <http://brew.sh/>`_ does not
+have the full SciPy stack available (i.e. you cannot do ``brew install <formula>``
+for everything).
 
 .. _individual-packages:
+
+Windows packages
+----------------
+
+Windows does not have any package manager analogous to that in Linux, so installing
+one of the scientific Python distributions mentioned above is preferred. However, if
+that is not an option, Christoph Gohlke provides `pre-built Windows installers <http://www.lfd.uci.edu/~gohlke/pythonlibs/>`_
+for many Python packages, including all of the core SciPy stack, which work extremely well.
 
 Individual binary and source packages
 -------------------------------------
@@ -105,12 +115,7 @@ with the Python binaries available from python.org.
 *  `sympy <https://github.com/sympy/sympy/releases>`_
 *  `nose <https://nose.readthedocs.org/en/latest/>`_
 
-For Windows: Christoph Gohlke provides `pre-built Windows installers
-<http://www.lfd.uci.edu/~gohlke/pythonlibs/>`_ for many Python
-packages, including all of the core SciPy stack.
-
 You can also build any of the SciPy packages from source, for instance if you
 want to get involved with development. This is easy for packages written
 entirely in Python, while others like NumPy require compiling C code. Refer to
 individual projects for more details.
-

--- a/www/install.rst
+++ b/www/install.rst
@@ -47,7 +47,7 @@ Fedora
 
 ::
 
-    sudo yum install numpy scipy python-matplotlib ipython python-pandas sympy python-nose
+    sudo yum install numpy scipy python-matplotlib ipython python-pandas sympy python-nose blas-devel lapack-devel
 
 Users of Fedora 17 and earlier should then upgrade IPython using pip::
 

--- a/www/install.rst
+++ b/www/install.rst
@@ -47,7 +47,7 @@ Fedora
 
 ::
 
-    sudo yum install numpy scipy python-matplotlib ipython python-pandas sympy python-nose blas-devel lapack-devel
+    sudo yum install numpy scipy python-matplotlib ipython python-pandas sympy python-nose atlas-devel lapack-devel
 
 The versions in Fedora 17 or newer meet the current SciPy stack specification.
 

--- a/www/topical-software.rst
+++ b/www/topical-software.rst
@@ -235,6 +235,10 @@ Optimization
 
 - `lmfit-py <https://lmfit.github.io/lmfit-py/>`__ is a wrapper around scipy.optimize.leastsq that uses named fitting parameters which may be varied, fixed, or constrained with simple mathematical expressions.
 
+- `noisyopt <https://github.com/andim/noisyopt>`__: provides algorithms for the optimization of noisy functions including pattern search with adaptive sampling and simultaneous perturbation stochastic approximation 
+
+- `scipydirect <https://github.com/andim/scipydirect>`__: is a wrapper about the DIRECT algorithm for global optimization. 
+
 Systems of nonlinear equations
 ==============================
 

--- a/www/topical-software.rst
+++ b/www/topical-software.rst
@@ -251,7 +251,7 @@ Automatic differentiation
 - `pycppad <http://www.seanet.com/~bradbell/pycppad/index.htm>`__ - wrapper for CppAD, second order forward/reverse
 - `pyadolc <https://github.com/b45ch1/pyadolc>`__ - wrapper for ADOL-C, arbitrary order forward/reverse
 - `algopy <http://pythonhosted.org/algopy/>`__ - evaluation of higher-order derivatives in the forward and reverse mode of algorithmic differentiation, with a particular focus on numerical linear algebra
-- `CasADi <https://github.com/casadi/casadi/wiki>`__ - a symbolic framework for algorithmic (a.k.a. automatic) differentiation and numeric optimization
+- `CasADi <http://casadi.org>`__ - a symbolic framework for algorithmic (a.k.a. automatic) differentiation and numeric optimization
 - `autograd <https://github.com/HIPS/autograd>`__ - efficient automatic differentiation with good support for code using Numpy.
 
 Finite differences derivatives approximation


### PR DESCRIPTION
Advises users to Fedora/CentOS/etc. to install dev versions of BLAS/LAPACK so that subsequent upgrades via `pip` will not fail.