### PR TITLE
added noisyopt and scipydirect to python optimization topical software

### DIFF
--- a/www/topical-software.rst
+++ b/www/topical-software.rst
@@ -235,6 +235,10 @@ Optimization
 
 - `lmfit-py <https://lmfit.github.io/lmfit-py/>`__ is a wrapper around scipy.optimize.leastsq that uses named fitting parameters which may be varied, fixed, or constrained with simple mathematical expressions.
 
+- `noisyopt <https://github.com/andim/noisyopt>`__: provides algorithms for the optimization of noisy functions including pattern search with adaptive sampling and simultaneous perturbation stochastic approximation 
+
+- `scipydirect <https://github.com/andim/scipydirect>`__: is a wrapper about the DIRECT algorithm for global optimization. 
+
 Systems of nonlinear equations
 ==============================
 


### PR DESCRIPTION
Hi,

I would like to add two optimization packages to the topical software list.

The first, noisyopt https://github.com/andim/noisyopt, is a library for the optimization of noisy functions. It currently includes a stochastic perturbation stochastic approximation algorithm and a pattern search algorithm with adaptive sampling.

The second, scipydirect https://github.com/andim/scipydirect, is a wrapper around the DIRECT global optimization algorithm.

Both packages are lightweight and provide a scipy.optimize compatible call syntax to allow easy interchangeability with the optimization algorithms from scipy, which is crucial to allow fast testing of different algorithms on a given optimization problem.

Cheers
Andreas