### PR TITLE
DOC: update and clean up install instructions

### DIFF
--- a/www/install.rst
+++ b/www/install.rst
@@ -117,7 +117,7 @@ Homebrew
 At the time of writing (September 2016), `Homebrew <http://brew.sh/>`_ does
 not have the full SciPy stack available (i.e. you cannot do ``brew install
 <formula>`` for everything).  You can install NumPy, SciPy and Matplotlib,
-with ``brew tap homebrew/python.
+with ``brew tap homebrew/python; brew install python numpy scipy matplotlib``.
 
 .. _individual-packages:
 

--- a/www/install.rst
+++ b/www/install.rst
@@ -43,7 +43,8 @@ To install via pip on Mac or Linux, first upgrade pip to the latest version::
     python -m pip install --upgrade pip
 
 Then install the SciPy stack packages with pip.  We recommend a *user*
-install, using the ``--user`` flag to pip.  This installs packages for your
+install, using the ``--user`` flag to pip (note: don't use ``sudo pip``, that
+will give problems).  This installs packages for your
 local user, and does not need extra permissions to write to the system
 directories::
 

--- a/www/install.rst
+++ b/www/install.rst
@@ -29,34 +29,28 @@ Installing via pip
 ------------------
 
 Mac and Linux users can install pre-built binary packages for the SciPy stack
-using `pip <https://pip.pypa.io/en/stable>`_.  pip is the installation tool
-recommended by the `Python Packaging Authority <https://www.pypa.io>`_. Pip
-can install pre-built binary packages in the `wheel
-<http://wheel.readthedocs.io>`_ package format.
+using `pip <https://pip.pypa.io/en/stable>`_.  Pip can install pre-built binary
+packages in the `wheel <http://wheel.readthedocs.io>`_ package format.
+
+*Note that you need to have Python and pip already installed on your system.*
 
 *pip does not work well for Windows* because the standard pip package index
-site, `pypi <https://pypi.python.org/pypi>`_, does not yet have Windows wheels
+site, `PyPI <https://pypi.python.org/pypi>`_, does not yet have Windows wheels
 for some packages, such as SciPy.
 
-To install via pip on Mac or Linux, first upgrade pip to the latest version.
-For Python 3::
+To install via pip on Mac or Linux, first upgrade pip to the latest version::
 
-    python3 -m pip install --upgrade pip
-
-Replace ``python3`` with ``python2`` for Python 2 pip upgrade.
+    python -m pip install --upgrade pip
 
 Then install the SciPy stack packages with pip.  We recommend a *user*
 install, using the ``--user`` flag to pip.  This installs packages for your
 local user, and does not need extra permissions to write to the system
 directories::
 
-    pip3 install --user numpy scipy matplotlib ipython jupyter pandas sympy nose
-
-Use ``pip2`` instead of ``pip3`` for Python 2 installs.
+    pip install --user numpy scipy matplotlib ipython jupyter pandas sympy nose
 
 For user installs, make sure your user install executable directory is on your
-PATH.  Here are example commands for setting the user PATH where the user is
-using Python 3 by default:
+PATH.  Here are example commands for setting the user PATH::
 
 Linux::
 
@@ -68,7 +62,7 @@ OSX::
     # Consider adding this at the end of your ~/.bash_profile file
     export PATH="$PATH:/Users/your_user/Library/Python/3.5/bin"
 
-Replace ``your_user`` with your username.
+Replace ``your_user`` with your username, and "3.5" with your Python version.
 
 Install systemwide via a Linux package manager
 ----------------------------------------------

--- a/www/install.rst
+++ b/www/install.rst
@@ -78,6 +78,10 @@ repositories for various distributions.  These installations will be
 system-wide, and will be somewhat out of date compared to versions installed
 with pip.
 
+The install commands for the most common Linux distributions are given here.
+For other distributions, search the default package repository for package
+names of individual packages in the :ref:`SciPy stack <stackspec>`.
+
 Ubuntu & Debian
 ~~~~~~~~~~~~~~~
 
@@ -96,26 +100,8 @@ Fedora 22 and later::
 
     sudo dnf install numpy scipy python-matplotlib ipython python-pandas sympy python-nose atlas-devel
 
-Fedora 21 or earlier::
-
-    sudo yum install numpy scipy python-matplotlib ipython python-pandas sympy python-nose atlas-devel
-
 The versions in Fedora 17 or newer meet the current SciPy stack specification.
 
-Gentoo
-~~~~~~
-
-::
-
-    sudo emerge -aN '>=dev-python/numpy-1.6' '>=sci-libs/scipy-0.10' '>=dev-python/matplotlib-1.1' '>=dev-python/ipython-0.13' '>=dev-python/pandas-0.8' '>=dev-python/sympy-0.7' '>=dev-python/nose-1.1'
-
-You may get some messages saying that keyword changes or USE changes are
-necessary in order to proceed, and that you should use ``--autounmask-write`` to
-write changes to config files.
-
-If this happens, just run the above command with ``--autounmask-write``
-appended, then run ``sudo dispatch-conf`` (or an alternative) to save the
-configuration changes, and finally run the original command again.
 
 Install systemwide via a Mac package manager
 ----------------------------------------------
@@ -126,10 +112,10 @@ of popular package managers you can install.
 Macports
 ~~~~~~~~
 
-To install the SciPy stack for Python 2.7 with `Macports
+To install the SciPy stack for Python 3.5 with `Macports
 <http://www.macports.org>`_ execute this command in a terminal::
 
-    sudo port install py27-numpy py27-scipy py27-matplotlib py27-ipython +notebook py27-pandas py27-sympy py27-nose
+    sudo port install py35-numpy py35-scipy py35-matplotlib py35-ipython +notebook py35-pandas py35-sympy py35-nose
 
 Homebrew
 ~~~~~~~~
@@ -137,8 +123,7 @@ Homebrew
 At the time of writing (September 2016), `Homebrew <http://brew.sh/>`_ does
 not have the full SciPy stack available (i.e. you cannot do ``brew install
 <formula>`` for everything).  You can install NumPy, SciPy and Matplotlib,
-with ``brew tap homebrew/python; brew install python numpy scipy matplotlib``,
-but we recommend pip installs in preference to the homebrew builds.
+with ``brew tap homebrew/python.
 
 .. _individual-packages:
 


### PR DESCRIPTION
- Use Python 3.5 by default.
- Remove Gentoo, outdated and not big enough to maintain.
- Explain that for pip instructions to work, Python and pip need to already be installed.
- some minor cleanups