### PR TITLE
Update content on constituent packages

### DIFF
--- a/www/about.rst
+++ b/www/about.rst
@@ -44,7 +44,7 @@ Data and computation:
 * scikit-learn_ is a collection of algorithms and tools for machine learning.
 * h5py_ and PyTables_ can both access data stored in the HDF5 format.
 
-Productivity and high-perormance computing:
+Productivity and high-performance computing:
 
 * IPython_, a rich interactive interface, letting you quickly process data and
   test ideas.

--- a/www/about.rst
+++ b/www/about.rst
@@ -39,25 +39,21 @@ Core Packages
 * SymPy_, for symbolic mathematics and computer algebra.
 * IPython_, a rich interactive interface, letting you quickly process data and
   test ideas.
-* The Jupyter_ notebook provides IPython functionality and more in your web
-  browser, allowing you to document your computation in an easily reproducible form.
+* nose_, a framework for testing Python code, being phased out in preference for pytest_.
 
 Other packages
 ##############
 
-There are many more packages built on this stack - too many to list here. This
+There are :doc:`many more relevant packages <topical-software>`. This
 is a brief overview of a few major ones:
 
-* Mayavi_ is a powerful and user-friendly framework for 3D visualization, 
-  built on top of the award winning Visualization Toolkit, VTK_.
+* The Jupyter_ notebook provides IPython functionality and more in your web
+  browser, allowing you to document your computation in an easily reproducible form.
 * Cython_ extends Python syntax so that you can conveniently build C extensions,
   either to speed up critical code, or to integrate with C/C++ libraries.
 * scikit-image_ is a collection of algorithms for image processing.
 * scikit-learn_ is a collection of algorithms and tools for machine learning.
-* Further Scikits_ are available providing more specific functionality. 
 * h5py_ and PyTables_ can both access data stored in the HDF5 format.
-
-See the :doc:`topical-software` page for more.
 
 .. _NumPy: http://www.numpy.org/
 .. _Matplotlib: http://matplotlib.org/
@@ -73,6 +69,7 @@ See the :doc:`topical-software` page for more.
 .. _h5py: http://www.h5py.org
 .. _PyTables: http://www.pytables.org
 .. _Jupyter: http://jupyter.org/
+.. _pytest: https://docs.pytest.org/
 
 .. ETS stuff
 .. _Enthought Tool Suite: http://code.enthought.com/projects/index.php

--- a/www/about.rst
+++ b/www/about.rst
@@ -57,8 +57,7 @@ Productivity and high-perormance computing:
 Quality assurance:
 
 * nose_, a framework for testing Python code, being phased out in preference for pytest_.
-
-
+* numpydoc_, a standard and library for documenting Scientific Python libraries.
 
 .. _NumPy: http://www.numpy.org/
 .. _Matplotlib: http://matplotlib.org/
@@ -78,6 +77,7 @@ Quality assurance:
 .. _Dask: https://dask.readthedocs.io/
 .. _Joblib: https://joblib.readthedocs.io/
 .. _IPyParallel: https://ipyparallel.readthedocs.io/
+.. _numpydoc: https://github.com/numpy/numpydoc
 
 .. ETS stuff
 .. _Enthought Tool Suite: http://code.enthought.com/projects/index.php

--- a/www/about.rst
+++ b/www/about.rst
@@ -38,9 +38,9 @@ Core Packages
 * pandas_, providing high-performance, easy to use data structures.
 * SymPy_, for symbolic mathematics and computer algebra.
 * IPython_, a rich interactive interface, letting you quickly process data and
-  test ideas. The **IPython notebook** works in your web browser, allowing you
-  to document your computation in an easily reproducible form.
-* nose_, a framework for testing Python code.
+  test ideas.
+* The Jupyter_ notebook provides IPython functionality and more in your web
+  browser, allowing you to document your computation in an easily reproducible form.
 
 Other packages
 ##############
@@ -48,15 +48,13 @@ Other packages
 There are many more packages built on this stack - too many to list here. This
 is a brief overview of a few major ones:
 
-* Chaco_ is another Python plotting toolkit designed from the ground up to be 
-  great for embedded, interactive plotting. It is built on Traits_, both are
-  part of the `Enthought Tool Suite`_.
 * Mayavi_ is a powerful and user-friendly framework for 3D visualization, 
   built on top of the award winning Visualization Toolkit, VTK_.
 * Cython_ extends Python syntax so that you can conveniently build C extensions,
   either to speed up critical code, or to integrate with C/C++ libraries.
-* Scikits_ are extra packages for more specific functionality. scikit-image_
-  and scikit-learn_ are two of the most prominent.
+* scikit-image_ is a collection of algorithms for image processing.
+* scikit-learn_ is a collection of algorithms and tools for machine learning.
+* Further Scikits_ are available providing more specific functionality. 
 * h5py_ and PyTables_ can both access data stored in the HDF5 format.
 
 See the :doc:`topical-software` page for more.
@@ -74,6 +72,7 @@ See the :doc:`topical-software` page for more.
 .. _scikit-learn: http://scikit-learn.org/
 .. _h5py: http://www.h5py.org
 .. _PyTables: http://www.pytables.org
+.. _Jupyter: http://jupyter.org/
 
 .. ETS stuff
 .. _Enthought Tool Suite: http://code.enthought.com/projects/index.php

--- a/www/about.rst
+++ b/www/about.rst
@@ -10,20 +10,18 @@ Scientific Computing Tools for Python
 
 SciPy refers to several related but distinct entities:
 
-* The *SciPy Stack*, a collection of open source software for scientific
-  computing in Python, and particularly a :doc:`specified set of core packages
-  <stackspec>`.
+* The *SciPy ecosystem*, a collection of open source software for scientific
+  computing in Python.
 * The *community* of people who use and develop this stack.
 * Several *conferences* dedicated to scientific computing in Python - SciPy,
   EuroSciPy and SciPy.in.
 * The :doc:`SciPy library <scipylib/index>`, one component of the SciPy stack,
   providing many numerical routines.
 
-The SciPy Stack
----------------
+The SciPy ecosystem
+-------------------
 
-Core Packages
-#############
+Scientific computing in Python builds upon a small core of packages:
 
 * Python_, a general purpose programming language. It is interpreted and
   dynamically typed and is very suited for interactive work and quick
@@ -35,25 +33,32 @@ Core Packages
   statistics and much more.
 * Matplotlib_, a mature and popular plotting package, that provides 
   publication-quality 2D plotting as well as rudimentary 3D plotting
+
+On this base, the SciPy ecosystem includes general and specialised tools for data management and computation, productive experimentation and high-performance computing. Below we overview some key packages, though there are :doc:`many more relevant packages <topical-software>`.
+
+Data and computation:
+
 * pandas_, providing high-performance, easy to use data structures.
 * SymPy_, for symbolic mathematics and computer algebra.
+* scikit-image_ is a collection of algorithms for image processing.
+* scikit-learn_ is a collection of algorithms and tools for machine learning.
+* h5py_ and PyTables_ can both access data stored in the HDF5 format.
+
+Productivity and high-perormance computing:
+
 * IPython_, a rich interactive interface, letting you quickly process data and
   test ideas.
-* nose_, a framework for testing Python code, being phased out in preference for pytest_.
-
-Other packages
-##############
-
-There are :doc:`many more relevant packages <topical-software>`. This
-is a brief overview of a few major ones:
-
 * The Jupyter_ notebook provides IPython functionality and more in your web
   browser, allowing you to document your computation in an easily reproducible form.
 * Cython_ extends Python syntax so that you can conveniently build C extensions,
   either to speed up critical code, or to integrate with C/C++ libraries.
-* scikit-image_ is a collection of algorithms for image processing.
-* scikit-learn_ is a collection of algorithms and tools for machine learning.
-* h5py_ and PyTables_ can both access data stored in the HDF5 format.
+* Dask_, Joblib_ or IPyParallel_ for distributed processing with a focus on numeric data.
+
+Quality assurance:
+
+* nose_, a framework for testing Python code, being phased out in preference for pytest_.
+
+
 
 .. _NumPy: http://www.numpy.org/
 .. _Matplotlib: http://matplotlib.org/
@@ -70,6 +75,9 @@ is a brief overview of a few major ones:
 .. _PyTables: http://www.pytables.org
 .. _Jupyter: http://jupyter.org/
 .. _pytest: https://docs.pytest.org/
+.. _Dask: https://dask.readthedocs.io/
+.. _Joblib: https://joblib.readthedocs.io/
+.. _IPyParallel: https://ipyparallel.readthedocs.io/
 
 .. ETS stuff
 .. _Enthought Tool Suite: http://code.enthought.com/projects/index.php

--- a/www/stackspec.rst
+++ b/www/stackspec.rst
@@ -4,6 +4,12 @@
 The SciPy Stack specification
 =============================
 
+.. deprecated::
+
+    The SciPy Stack Specification was developed in 2012.
+    As of 2017, the SciPy Stack concept is obsolete given
+    improvements in package management and distribution.
+
 Python Distributions promoting themselves as providing the SciPy stack should
 meet the requirements listed below.
 


### PR DESCRIPTION
* IPython Notebooks have been renamed
* Chaco and Mayavi seem to have lacked in traction and continued development
* Nose is unmaintained and not recommended
* scikit-{learn,image} deserve separate descriptions.