### PR TITLE
Change installation instructions to promote pip + remove references to "scipy stack"

### DIFF
--- a/www/install.rst
+++ b/www/install.rst
@@ -1,139 +1,108 @@
-==========================
-Installing the SciPy Stack
-==========================
+===================
+Installing packages
+===================
 
-These are instructions for installing :ref:`the full SciPy stack
-<stackspec>`.  For installing individual packages, such as NumPy and
-SciPy, see :ref:`individual-packages` below.
+These are general instructions for installing packages in the SciPy
+ecosystem.
 
 Scientific Python distributions
 -------------------------------
 
-For most users, especially on Windows, the easiest way to install the packages
-of the SciPy stack is to download one of these Python distributions, which
-include all the key packages:
+For many users, especially on Windows, the easiest way to begin is to
+download one of these Python distributions, which include all the key
+packages:
 
 * `Anaconda <https://www.continuum.io/downloads>`_: A free distribution
-  for the SciPy stack.  Supports Linux, Windows and Mac.
+  of Python with scientific packages.  Supports Linux, Windows and Mac.
 * `Enthought Canopy <https://www.enthought.com/products/canopy>`_: The free and
-  commercial versions include the core SciPy stack packages.
+  commercial versions include the core scientific packages.
   Supports Linux, Windows and Mac.
 * `Python(x,y) <https://python-xy.github.io/>`_: A free distribution
-  including the SciPy stack, based around the Spyder IDE.  Windows only.
+  including scientific packages, based around the Spyder IDE.  Windows only.
 * `WinPython <https://winpython.github.io>`_: A free distribution
-  including the SciPy stack.  Windows only.
+  including scientific packages.  Windows only.
 * `Pyzo <http://www.pyzo.org/>`_: A free distribution based on Anaconda and the
   IEP interactive development environment.  Supports Linux, Windows and Mac.
+
+.. _pip-install:
 
 Installing via pip
 ------------------
 
-Mac and Linux users can install pre-built binary packages for the SciPy stack
-using `pip <https://pip.pypa.io/en/stable>`_.  Pip can install pre-built binary
-packages in the `wheel <https://wheel.readthedocs.io>`_ package format.
+Most major projects upload official packages to the `Python Package
+index <https://pypi.org>`_.  They can be installed on most operating
+systems using Python's standard `pip <https://pip.pypa.io/en/stable>`_
+package manager.
 
 *Note that you need to have Python and pip already installed on your system.*
 
-*pip does not work well for Windows* because the standard pip package index
-site, `PyPI <https://pypi.python.org/pypi>`_, does not yet have Windows wheels
-for some packages, such as SciPy.
+You can install packages via commands such as::
 
-To install via pip on Mac or Linux, first upgrade pip to the latest version::
+    python -m pip install --user numpy scipy matplotlib ipython jupyter pandas sympy nose
 
-    python -m pip install --upgrade pip
+We recommend using an *user* install, using the ``--user`` flag to pip
+(note: do not use ``sudo pip``, which can cause problems).  This
+installs packages for your local user, and does not write to the
+system directories.
 
-Then install the SciPy stack packages with pip.  We recommend a *user*
-install, using the ``--user`` flag to pip (note: don't use ``sudo pip``, that
-will give problems).  This installs packages for your
-local user, and does not need extra permissions to write to the system
-directories::
+Install system-wide via a Linux package manager
+-----------------------------------------------
 
-    pip install --user numpy scipy matplotlib ipython jupyter pandas sympy nose
+Users on Linux can install packages from repositories provided by the
+distributions.  These installations will be system-wide, and may have
+older package versions than those available using pip.
 
-For user installs, make sure your user install executable directory is on your
-PATH.  Here are example commands for setting the user PATH:
-
-Linux::
-
-    # Consider adding this at the end of your ~/.bashrc file
-    export PATH="$PATH:/home/your_user/.local/bin"
-
-OSX::
-
-    # Consider adding this at the end of your ~/.bash_profile file
-    export PATH="$PATH:/Users/your_user/Library/Python/3.5/bin"
-
-Replace ``your_user`` with your username, and "3.5" with your Python version.
-
-Install systemwide via a Linux package manager
-----------------------------------------------
-
-Users on Linux can quickly install the necessary packages from standard
-repositories for various distributions.  These installations will be
-system-wide, and will be somewhat out of date compared to versions installed
-with pip.
-
-The install commands for the most common Linux distributions are given here.
-For other distributions, search the default package repository for package
-names of individual packages in the :ref:`SciPy stack <stackspec>`.
-
-Ubuntu & Debian
-~~~~~~~~~~~~~~~
+.. rubric:: Ubuntu & Debian
 
 ::
 
     sudo apt-get install python-numpy python-scipy python-matplotlib ipython ipython-notebook python-pandas python-sympy python-nose
 
-The versions in Ubuntu 12.10 or newer and Debian 7.0 or newer meet the current
-SciPy stack specification. Users might also want to add the `NeuroDebian
-repository <http://neuro.debian.net>`_ for extra SciPy packages.
+Users might also want to add the `NeuroDebian repository
+<http://neuro.debian.net>`_ for extra SciPy packages.
 
-Fedora
-~~~~~~
+.. rubric:: Fedora
 
 Fedora 22 and later::
 
     sudo dnf install numpy scipy python-matplotlib ipython python-pandas sympy python-nose atlas-devel
 
-The versions in Fedora 17 or newer meet the current SciPy stack specification.
 
+Install system-wide via a Mac package manager
+---------------------------------------------
 
-Install systemwide via a Mac package manager
-----------------------------------------------
-
-Macs (unlike Linux) don't come with a package manager, but there are a couple
+Macs don't have a preinstalled package manager, but there are a couple
 of popular package managers you can install.
 
-Macports
-~~~~~~~~
+.. rubric:: Macports
 
-To install the SciPy stack for Python 3.5 with `Macports
-<https://www.macports.org>`_ execute this command in a terminal::
+For Python 3.5 with `Macports <https://www.macports.org>`_ execute this command in a terminal::
 
     sudo port install py35-numpy py35-scipy py35-matplotlib py35-ipython +notebook py35-pandas py35-sympy py35-nose
 
-Homebrew
-~~~~~~~~
+.. rubric:: Homebrew
 
-At the time of writing (August 2017), `Homebrew <https://brew.sh>`_ does
-not have the full SciPy stack available (i.e. you cannot do ``brew install
-<formula>`` for everything).  You can install NumPy, SciPy, and Matplotlib,
-with ``brew tap homebrew/science && brew install python numpy scipy matplotlib``.
+You can install NumPy, SciPy, and Matplotlib, with::
+  
+    brew tap homebrew/science && brew install python numpy scipy matplotlib
 
 .. _individual-packages:
 
-Windows packages
-----------------
+Other alternatives
+------------------
 
-Windows does not have any package manager analogous to that in Linux, so installing
-one of the scientific Python distributions mentioned above is preferred. However, if
-that is not an option, Christoph Gohlke provides `pre-built Windows installers <http://www.lfd.uci.edu/~gohlke/pythonlibs>`_
-for many Python packages, including all of the core SciPy stack, which work extremely well.
+Official binary and source packages for most projects are available
+via ``pip`` as explained above.
 
-Individual source packages
---------------------------
+Binary packages are also available from third parties, such as the
+Python distributions above. For Windows, Christoph Gohlke provides `pre-built
+Windows installers <http://www.lfd.uci.edu/~gohlke/pythonlibs>`_ for
+many packages.
 
-You can build any of the SciPy packages from source, for instance if you
-want to get involved with development. This is easy for packages written
-entirely in Python, while others like NumPy require compiling C code. Refer to
-individual projects for more details.
+Source packages
+---------------
+
+You can build any of the packages from source, for instance if you
+want to get involved with development. This is easy for packages
+written entirely in Python, while others like NumPy require compiling
+C code. Refer to individual projects for more details.


### PR DESCRIPTION
Update the installation instructions:

- Remove references to the "scipy stack" (following #218)
- Promote using pip also on Windows

We may want to wait until scipy 1.0 is out in order to have the windows wheels...