### PR TITLE
Announce NumPy 1.14.3 release

### DIFF
--- a/www/index.rst
+++ b/www/index.rst
@@ -203,6 +203,9 @@ News
 .. role:: news-date
    :class: news-date
 
+NumPy 1.14.3 released :news-date:`2018-04-28`
+    See :doc:`/scipylib/download`.
+
 NumPy 1.14.2 released :news-date:`2018-03-12`
     See :doc:`/scipylib/download`.
 


### PR DESCRIPTION
Note: I also would like write permission to `docs.scipy.org` so I can upload the rebuilt docs with `make upload USERNAME=ahaldane RELEASE=v1.14.3`.