### PR TITLE
deprecate using homebrew to build numpy, scipy

### DIFF
--- a/www/install.rst
+++ b/www/install.rst
@@ -84,12 +84,18 @@ For Python 3.5 with `Macports <https://www.macports.org>`_ execute this command 
 
 .. rubric:: Homebrew
 
-Homebrew is not the correct way to install NumPy. We reccomend
-installing python, aliasing it, then using `pip`::
+Homebrew no longer packages NumPy or other packages of the scientific Python
+stack. If you're a Homebrew user, install
+[Python3 with Homebrew](https://docs.brew.sh/Homebrew-and-Python)::
 
     brew install python
-    # alias python to python3
-    python -m pip install numpy scipy ...
+    brew link python
+    python -c"import sys; print(sys.version)"
+    # if this does not show python3, these steps failed
+
+and the rest with pip::
+
+    python -m pip install numpy scipy matplotlib
 
 .. _individual-packages:
 

--- a/www/install.rst
+++ b/www/install.rst
@@ -86,13 +86,7 @@ For Python 3.5 with `Macports <https://www.macports.org>`_ execute this command 
 
 Homebrew no longer packages NumPy or other packages of the scientific Python
 stack. If you're a Homebrew user, install
-[Python3 with Homebrew](https://docs.brew.sh/Homebrew-and-Python)::
-
-    brew install python
-    brew link python
-    python -c"import sys; print(sys.version)"
-    # if this does not show python3, these steps failed
-
+[Python3 with Homebrew](https://docs.brew.sh/Homebrew-and-Python)
 and the rest with pip::
 
     python -m pip install numpy scipy matplotlib

--- a/www/install.rst
+++ b/www/install.rst
@@ -84,9 +84,12 @@ For Python 3.5 with `Macports <https://www.macports.org>`_ execute this command 
 
 .. rubric:: Homebrew
 
-You can install NumPy, SciPy, and Matplotlib, with::
+Homebrew is not the correct way to install NumPy. We reccomend
+installing python, aliasing it, then using `pip`::
 
-    brew tap homebrew/science && brew install python numpy scipy matplotlib
+    brew install python
+    # alias python to python3
+    python -m pip install numpy scipy ...
 
 .. _individual-packages:
 


### PR DESCRIPTION
As noted in numpy/numpy#11454 we should not recommend using homebrew to build scientific python packages.