### PR TITLE
Add back NumPy citation as secondary source

### DIFF
--- a/www/citing.rst
+++ b/www/citing.rst
@@ -68,12 +68,21 @@ __ http://scitation.aip.org/content/aip/journal/cise/9/3/10.1109/MCSE.2007.58
 __ https://doi.org/10.1109/MCSE.2011.36
 __ http://scitation.aip.org/content/aip/journal/cise/13/2/10.1109/MCSE.2011.36
 
+
 NumPy
 #####
 
-
 * Travis E, Oliphant. **A guide to NumPy**,
   USA: Trelgol Publishing, (2006).
+
+* Stéfan van der Walt, S. Chris Colbert and Gaël Varoquaux.
+  **The NumPy Array: A Structure for Efficient Numerical Computation**,
+  Computing in Science & Engineering, **13**, 22-30 (2011),
+  `DOI:10.1109/MCSE.2011.37`__ (`publisher link`__)
+
+__ http://dx.doi.org/10.1109/MCSE.2011.37
+__ http://scitation.aip.org/content/aip/journal/cise/13/2/10.1109/MCSE.2011.37
+
 
 IPython
 #######


### PR DESCRIPTION
I discussed this change with @rgommers.  I asked at some point that we remove the citation to my and Gaël's paper in favor of Travis's book.  However, I've received feedback that a) the new source is not available openly online, b) is harder to cite (no DOI, URL, etc.), and c) sends academic credit to a place where it is not very useful.  So, this PR adds the paper back as a *secondary* reference.  I leave the decision of whether to incorporate this change fully up to the team.

I think the solution, in the longer term, is to write a new NumPy paper.  Perhaps to accompany the release of NumPy 2.0, which shouldn't be too far off.  It will document all the changes that happened over the past two years, which are numerous.  I know there is interest in writing such a paper, and it may be the first to give some historical perspective on NumPy.

Also note that there is no "how to cite NumPy" section on numpy.org.  We may want to remedy that.