### PR TITLE
BLD: remove matplotlib.sphinxext.only_directive

### DIFF
--- a/www/conf.py
+++ b/www/conf.py
@@ -15,7 +15,6 @@ extensions = ['sphinx.ext.intersphinx',
               'ipython_console_highlighting',
               'sphinx.ext.ifconfig',
               'matplotlib.sphinxext.mathmpl',
-              'matplotlib.sphinxext.only_directives',
               'matplotlib.sphinxext.plot_directive']
 
 templates_path = ['_templates']


### PR DESCRIPTION
This was remove in MPL 3.0, and we didn't seem to use it anyway.

Can now use builtin ``only:: html`` rather than ``htmlonly::``