### PR TITLE
GH: add issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,12 @@
+<!--
+Thank you for taking the time to report a website issue.
+
+If your issue is about errors in the *documentation* of Scipy or
+Numpy, please use the appropriate bug trackers, not this one:
+
+- https://github.com/numpy/numpy/issues
+
+- https://github.com/scipy/scipy/issues
+
+-->
+


### PR DESCRIPTION
Attempt to direct people to use project bug trackers instead of this
one for errors in documentation.