### PR TITLE
Two links go to location for scipy tutorials and docs

### DIFF
--- a/www/_templates/sitenav.html
+++ b/www/_templates/sitenav.html
@@ -53,7 +53,7 @@ a.extlink:after {
   <ul class="nav nav-list">
     <li class="nav-header">Core packages:</li>
     <li><a class="extlink" href="http://www.numpy.org">Numpy</a> 
-    <li><a class="extlink" href="{{ pathto('scipylib/index') }}">SciPy library</a>
+    <li><a class="extlink" href="https://docs.scipy.org/doc/scipy/reference/">SciPy library</a>
     <li><a class="extlink" href="http://matplotlib.org">Matplotlib</a> 
     <li><a class="extlink" href="http://ipython.org">IPython</a> 
     <li><a class="extlink" href="http://sympy.org/">Sympy</a> 

--- a/www/index.rst
+++ b/www/index.rst
@@ -117,12 +117,12 @@ particular, these are some of the core packages:
   <li class="span4">
   <div class="thumbnail">
   <div class="pull-left img">
-    <a href="scipylib/index.html">
+    <a href="https://docs.scipy.org/doc/scipy/reference/">
     <img alt="scipy" src="_static/images/scipy_med.png" width="64">
     </a>
   </div>
   <div class="img-label">
-    <h4 class="media-heading"><a href="scipylib/index.html">SciPy library</a></h4>
+    <h4 class="media-heading"><a href="https://docs.scipy.org/doc/scipy/reference/">SciPy library</a></h4>
     Fundamental library for scientific computing
   </div>
   </div>


### PR DESCRIPTION
The route to get from scipy.org to the tutorials and documentation was confusing and involved unnecessary intermediaries.  I cleaned up two links.