### PR TITLE
DOC: update info on scientific distributions

### DIFF
--- a/www/install.rst
+++ b/www/install.rst
@@ -31,24 +31,20 @@ work on almost all setups, and provide all the commonly used scientific python t
 
 `Anaconda <https://www.anaconda.com/download/>`_ works on Windows, Mac, and
 Linux, provides over 1,500 Python/R packages, and is used by over 15 million
-people. Anaconda provides a lite version,
-`Miniconda <https://docs.conda.io/en/latest/miniconda.html>`_,
-which still provides access to the *conda* package manager.
+people. Anaconda is best suited to beginning users; it provides a large
+collection of libraries all in one.
+
+For more advanced users who will need to install or upgrade regularly,
+`Miniconda <https://docs.conda.io/en/latest/miniconda.html>`_ is a more
+suitable way to install the *conda* package manager.
 
 Other options include:
 
-* `Enthought Canopy <https://www.enthought.com/products/canopy>`_: Free and
-  commercial versions; supports Linux, Windows, and Mac; includes an IDE.
-* `Python(x,y) <https://python-xy.github.io/>`_: A free distribution including
-  scientific packages; based around the `Spyder IDE <https://www.spyder-ide.org/>`__;
-  Windows and Ubuntu; Py2 only.
 * `WinPython <https://winpython.github.io>`_: Another free distribution
   including scientific packages and the Spyder IDE; Windows only, but more
   actively maintained and supports the latest Python 3 versions.
 * `Pyzo <http://www.pyzo.org/>`_: A free distribution based on Anaconda and
   the IEP interactive development environment; Supports Linux, Windows, and Mac.
-* `NeuroDebian repository <http://neuro.debian.net>`_ : Only for the Debian OS
-  and geared toward neuroscientists.
 
 .. _pip-install:
 


### PR DESCRIPTION
Canopy and Python-xy are no longer developed. Not sure about NeuroDebian, but it's too specific to mention there.

Also be more accurate about Anaconda vs Miniconda - the latter is better for anyone beyond the beginner stage.