### PR TITLE
Fix BibTeX items

### DIFF
--- a/www/citing.rst
+++ b/www/citing.rst
@@ -31,27 +31,27 @@ Here's an example of a BibTeX entry:
 ::
 
     @ARTICLE{2020SciPy-NMeth,
-           author = {{Virtanen}, Pauli and {Gommers}, Ralf and {Oliphant},
-             Travis E. and {Haberland}, Matt and {Reddy}, Tyler and
-             {Cournapeau}, David and {Burovski}, Evgeni and {Peterson}, Pearu
-             and {Weckesser}, Warren and {Bright}, Jonathan and {van der Walt},
-             St{\'e}fan J.  and {Brett}, Matthew and {Wilson}, Joshua and
-             {Jarrod Millman}, K.  and {Mayorov}, Nikolay and {Nelson}, Andrew
-             R.~J. and {Jones}, Eric and {Kern}, Robert and {Larson}, Eric and
-             {Carey}, CJ and {Polat}, {\.I}lhan and {Feng}, Yu and {Moore},
-             Eric W. and {Vand erPlas}, Jake and {Laxalde}, Denis and
-             {Perktold}, Josef and {Cimrman}, Robert and {Henriksen}, Ian and
-             {Quintero}, E.~A. and {Harris}, Charles R and {Archibald}, Anne M.
-             and {Ribeiro}, Ant{\^o}nio H. and {Pedregosa}, Fabian and
-             {van Mulbregt}, Paul and {SciPy 1.0 Contributors}},
-            title = "{{SciPy} 1.0: Fundamental Algorithms for Scientific
-                      Computing in Python}",
-          journal = {Nature Methods},
-          year = {2020},
-          volume={17},
-          pages={261--272},
-          adsurl = {https://rdcu.be/b08Wh},
-          doi = {https://doi.org/10.1038/s41592-019-0686-2},
+      author  = {Virtanen, Pauli and Gommers, Ralf and Oliphant, Travis E. and
+                Haberland, Matt and Reddy, Tyler and Cournapeau, David and
+                Burovski, Evgeni and Peterson, Pearu and Weckesser, Warren and
+                Bright, Jonathan and {van der Walt}, St{\'e}fan J. and
+                Brett, Matthew and Wilson, Joshua and Millman, K. Jarrod and
+                Mayorov, Nikolay and Nelson, Andrew R. J. and Jones, Eric and
+                Kern, Robert and Larson, Eric and Carey, C J and
+                Polat, {\.I}lhan and Feng, Yu and Moore, Eric W. and
+                {VanderPlas}, Jake and Laxalde, Denis and Perktold, Josef and
+                Cimrman, Robert and Henriksen, Ian and Quintero, E. A. and
+                Harris, Charles R. and Archibald, Anne M. and
+                Ribeiro, Ant{\^o}nio H. and Pedregosa, Fabian and
+                {van Mulbregt}, Paul and {SciPy 1.0 Contributors}},
+      title   = {{{SciPy} 1.0: Fundamental Algorithms for Scientific
+                Computing in Python}},
+      journal = {Nature Methods},
+      year    = {2020},
+      volume  = {17},
+      pages   = {261--272},
+      adsurl  = {https://rdcu.be/b08Wh},
+      doi     = {10.1038/s41592-019-0686-2},
     }
 
 This supersedes the preprint in arXiv:1907.10121_


### PR DESCRIPTION
This PR does a few things:
* Move visually appealing line wrapping
* Fix `Vand erPlas` -> `VanderPlas` and (I think?) `{Jarrod Millman}, K.` -> `Millman, K. Jarrod`
* More common BibTeX style (e.g. don't need `{`/`}` for each surname, don't need `~` between first name initials)
* Remove `https://doi.org/` from doi entry