### PR TITLE
DOC fix link to the NumPy COC

### DIFF
--- a/www/codes-of-conduct.rst
+++ b/www/codes-of-conduct.rst
@@ -4,7 +4,7 @@ Codes of Conduct for the SciPy Ecosystem
 
 - `SciPy Code of Conduct <http://scipy.github.io/devdocs/dev/conduct/code_of_conduct.html>`__
 - `pandas Code of Conduct <https://github.com/pandas-dev/pandas-governance/blob/master/code-of-conduct.md>`__
-- `NumPy Code of Conduct <https://www.numpy.org/devdocs/dev/conduct/code_of_conduct.html>`__
+- `NumPy Code of Conduct <https://numpy.org/code-of-conduct/>__
 - Matplotlib Code of Conduct: Matplotlib `follows <https://matplotlib.org/#need-help>`__ the `Python Software Foundation Code of Conduct <https://www.python.org/psf/codeofconduct/>`__
 - `Sympy Code of Conduct <https://github.com/sympy/sympy/blob/master/CODE_OF_CONDUCT.md>`__
 - `Jupyter/IPython Code of Conduct


### PR DESCRIPTION
The current link for the NumPy COC is not available anymore.