### PR TITLE
Use the new structure for News

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -45,11 +45,6 @@ languages:
         buttonlink: "/install"
         # Hero image (from static/images/___)
         image: logo.svg
-      # Customizable navbar. For a dropdown, add a "sublinks" list.
-      news:
-        title: SciPy 1.7.2 released
-        content: 2021-11-05
-        url: /news
 
       keyfeatures:
         features:

--- a/content/en/news.md
+++ b/content/en/news.md
@@ -1,6 +1,8 @@
 ---
 title: News
 sidebar: false
+newsHeader: SciPy 1.7.2 released!
+date: 2021-11-05
 ---
 
 ### SciPy 1.7.2 released


### PR DESCRIPTION
News are now automatically generated from the `/news` folder. Each file is a news. The way it works is still being defined.

Right now it will create a single news which will be displayed on the front page. It will (after a theme update) link to the current news listing we already have.

- https://github.com/scientific-python/scientific-python-hugo-theme/pull/66

To be defined:

- Do we want to separate releases from news?
- Do we want to create a news per release? This is needed right now.
- Other requirements?

EDIT:

Upstream changes made it possible to stay with a single page and have the banner defined in the preamble. This PR update the theme and add the preamble keyword.

- https://github.com/scientific-python/scientific-python-hugo-theme/pull/71