### PR TITLE
Add lighthouse to neflify

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build.environment]
-  HUGO_VERSION = "0.92.0"
+  HUGO_VERSION = "0.92.1"
 
 [[redirects]]
   from = "/scipylib"
@@ -32,3 +32,18 @@
 [[redirects]]
   from = "/scipylib/faq.html"
   to = "/faq/"
+
+[[plugins]]
+  package = "@netlify/plugin-lighthouse"
+
+  # optional, fails build when a category is below a threshold
+  [plugins.inputs.thresholds]
+    performance = 0.5
+    accessibility = 0.9
+    best-practices = 0.9
+    seo = 0.9
+    pwa = 0.2
+
+  # optional, deploy the lighthouse report to a path under your site
+  [plugins.inputs]
+    output_path = "reports/lighthouse.html"


### PR DESCRIPTION
https://deploy-preview-441--scipy-org.netlify.app/reports/lighthouse.html

Here is the plugin we are using:
https://github.com/netlify-labs/netlify-plugin-lighthouse

I had to do two things:

1. Installed plugin in the Netlify UI from this [direct in-app installation link](https://app.netlify.com/plugins/@netlify/plugin-lighthouse/install).
2.  Add this
```
[[plugins]]
  package = "@netlify/plugin-lighthouse"

  # optional, fails build when a category is below a threshold
  [plugins.inputs.thresholds]
    performance = 0.5
    accessibility = 0.9
    best-practices = 0.9
    seo = 0.9
    pwa = 0.2

  # optional, deploy the lighthouse report to a path under your site
  [plugins.inputs]
    output_path = "reports/lighthouse.html"
``` 
to `netlify.toml`.  I changed `performance = 0.9` and `pwa = 0.9` to  `performance = 0.5` and `pwa = 0.2` b/c otherwise the CI failed.
```
Plugin "@netlify/plugin-lighthouse" failed

Error: Failed with error:

Error for directory 'public':
Expected category Performance to be greater or equal to 0.9 but got 0.62
Expected category Progressive Web App to be greater or equal to 0.9 but got 0.3
```
We should adjust the thresholds as we improve the theme.