### PR TITLE
Update Package Names for Fedora

### DIFF
--- a/content/en/install.md
+++ b/content/en/install.md
@@ -90,7 +90,7 @@ using apt-get:
 
 using dnf:
 
-    sudo dnf install numpy scipy python-matplotlib ipython python-pandas sympy python-nose atlas-devel
+    sudo dnf install python-numpy python-scipy python-matplotlib ipython python-pandas python-sympy python-nose atlas-devel
 
 ## Mac
 

--- a/content/en/install.md
+++ b/content/en/install.md
@@ -86,7 +86,7 @@ using apt-get:
 
     sudo apt-get install python-numpy python-scipy python-matplotlib ipython ipython-notebook python-pandas python-sympy python-nose
 
-## Fedora 22 and later
+## Fedora
 
 using dnf:
 

--- a/content/en/install.md
+++ b/content/en/install.md
@@ -90,7 +90,7 @@ using apt-get:
 
 using dnf:
 
-    sudo dnf install python-numpy python-scipy python-matplotlib ipython python-pandas python-sympy python-nose atlas-devel
+    sudo dnf install python3-numpy python3-scipy python3-matplotlib ipython python3-pandas python3-sympy python3-nose atlas-devel
 
 ## Mac
 

--- a/content/en/install.md
+++ b/content/en/install.md
@@ -90,7 +90,7 @@ using apt-get:
 
 using dnf:
 
-    sudo dnf install python3-numpy python3-scipy python3-matplotlib ipython python3-pandas python3-sympy python3-nose atlas-devel
+    sudo dnf install python3-numpy python3-scipy python3-matplotlib python3-ipython python3-pandas python3-sympy python3-pytest
 
 ## Mac
 


### PR DESCRIPTION
Following the installation guide to install scipy system wide on fedora:
`sudo dnf install numpy scipy python-matplotlib ipython python-pandas sympy python-nose atlas-devel`
Produces the error:
```
No match for argument: scipy
No match for argument: sympy
Error: Unable to find a match: scipy sympy
```
I've updated the guide to include the correct package names:
`sudo dnf install python-numpy python-scipy python-matplotlib ipython python-pandas python-sympy python-nose atlas-devel`

