### PR TITLE
Fix a dead link for contributors in the about page.

### DIFF
--- a/content/en/about.md
+++ b/content/en/about.md
@@ -77,7 +77,7 @@ Partners include:
 SciPy will always be 100% open source software, free for all to use and
 released under the liberal terms of the modified BSD license. While we
 have a large number of
-[contributors](https://github.com/scipy/scipy/blob/main/THANKS.txt)
+[contributors](https://github.com/scipy/scipy/graphs/contributors)
 who volunteer their time to improve SciPy, financial resources are
 needed to run the project and accelerate its development. If you have
 found SciPy useful in your work, research, or company, please consider


### PR DESCRIPTION
I fixed a dead link for contributors in the [about](https://scipy.org/about/) page.
The THANKS.txt file does not exist now.
I think GitHub’s [contributors](https://github.com/scipy/scipy/graphs/contributors) page is a good option.
Let me know if there is any other good option.