### PR TITLE
Doc URL to released version and meetups

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -91,7 +91,7 @@ languages:
             - text: Install
               link: /install
             - text: Documentation
-              link: https://scipy.github.io/devdocs/index.html
+              link: https://docs.scipy.org/doc/scipy/
             - text: Citing SciPy
               link: /citing-scipy
             - text: Roadmap

--- a/config.yaml
+++ b/config.yaml
@@ -69,7 +69,7 @@ languages:
       - title: Install
         url: /install
       - title: Documentation
-        url: https://scipy.github.io/devdocs/index.html
+        url: https://docs.scipy.org/doc/scipy/
       - title: Download
         url: /download
       - title: Community

--- a/content/en/community.md
+++ b/content/en/community.md
@@ -19,6 +19,12 @@ The following are ways to engage directly with the SciPy project and community.
 _Please note that we encourage users and community members to support each
 other for usage questions - see [Get Help](/gethelp)._
 
+### [SciPy community meetings](https://scientific-python.org/calendars/)
+
+The Scientific Python community is organizing various meetings. SciPy
+community meetings are ideal to anyone wanting to contribute to SciPy or just
+know how current development is going.
+
 ### [SciPy mailing list](https://mail.python.org/mailman3/lists/scipy-dev.python.org/)
 
 This list is the main forum for longer-form discussions, like adding new

--- a/content/en/community.md
+++ b/content/en/community.md
@@ -21,9 +21,8 @@ other for usage questions - see [Get Help](/gethelp)._
 
 ### [SciPy community meetings](https://scientific-python.org/calendars/)
 
-The Scientific Python community is organizing various meetings. SciPy
-community meetings are ideal to anyone wanting to contribute to SciPy or just
-know how current development is going.
+SciPy community meetings are ideal to anyone wanting to contribute to SciPy
+or just know how current development is going.
 
 ### [SciPy mailing list](https://mail.python.org/mailman3/lists/scipy-dev.python.org/)
 


### PR DESCRIPTION
The documentation url was set to develop due to broken links. Since this issue is resolved, we can use the proper released version url.

I took the (lazy) opportunity to add SciPy meeting.