### PR TITLE
Fix broken link to build instructions

### DIFF
--- a/content/en/download.md
+++ b/content/en/download.md
@@ -47,7 +47,7 @@ To check out the latest **SciPy** sources:
 
 Build instructions for SciPy can be found in its documentation. The
 latest version can be found at:
-<https://scipy.github.io/devdocs/building/index.html>
+<https://docs.scipy.org/doc/scipy/building>
 
 # Third-party/vendor package managers
 


### PR DESCRIPTION
I checked with [archive.org](https://web.archive.org/web/20210303001538/https://scipy.github.io/devdocs/building/index.html) that this is the right page to link to.