### PR TITLE
Update Package Names for Debian and Ubuntu

### DIFF
--- a/content/en/install.md
+++ b/content/en/install.md
@@ -84,7 +84,7 @@ and don\'t have as many available versions.
 
 using apt-get:
 
-    sudo apt-get install python-numpy python-scipy python-matplotlib ipython ipython-notebook python-pandas python-sympy python-nose
+    sudo apt-get install python3-numpy python3-scipy python3-matplotlib ipython3 python3-notebook python3-pandas python3-sympy python3-nose
 
 ## Fedora
 


### PR DESCRIPTION
Hi, current installation guidelines for Ubuntu and Debian produce the following error in Debian 11 (stable) and Ubuntu LTS (20.04, 22.04):

```
E: Unable to locate package python-numpy
E: Package 'python-scipy' has no installation candidate
E: Package 'python-matplotlib' has no installation candidate
E: Package 'ipython' has no installation candidate
E: Unable to locate package ipython-notebook
E: Unable to locate package python-pandas
E: Package 'python-sympy' has no installation candidate
E: Package 'python-nose' has no installation candidate
```
I have updated the instructions to include the correct package names.

Thank you.