### PR TITLE
Add LANL institutional partner

### DIFF
--- a/content/en/about.md
+++ b/content/en/about.md
@@ -73,6 +73,8 @@ Partners include:
 
 {{< partners >}}
 
+- Los Alamos National Laboratory (Tyler Reddy)
+
 ## Donate
 
 SciPy will always be 100% open source software, free for all to use and


### PR DESCRIPTION
* pleased to report I'm covered at 20 % time and effort by LANL for SciPy/NumPy work now; this is not the same pot of funding as NASA ROSES, though those grant meetings still make sense as a coordination point I think

* permission to use the LANL logo is tricky--I think this is good enough unless they tell me otherwise; I couldn't quite decide if we wanted the list of partners and then the subset of logos below, but since it is just Quansight logo for now I just went under that logo, feel free to adjust..