### PR TITLE
Add links to calendar and mention new contributors meeting

### DIFF
--- a/content/en/community.md
+++ b/content/en/community.md
@@ -22,7 +22,16 @@ other for usage questions - see [Get Help](/gethelp)._
 ### [SciPy community meetings](https://scientific-python.org/calendars/)
 
 SciPy community meetings are ideal to anyone wanting to contribute to SciPy
-or just know how current development is going.
+or just know how current development is going. You can follow
+[our community calendar](https://scientific-python.org/calendars/) from your
+preferred calendar manager, or look out for the announcements on our mailing
+list. 
+
+### [SciPy new contributor meetings](https://scientific-python.org/calendars/)
+
+Once a month we have special meetings for folks who want to start contributing
+or have just started. All are welcome! Check our community calendar for details,
+or look out for the announcements on our mailing list.
 
 ### [SciPy mailing list](https://mail.python.org/mailman3/lists/scipy-dev.python.org/)
 

--- a/content/en/community.md
+++ b/content/en/community.md
@@ -25,7 +25,7 @@ SciPy community meetings are ideal to anyone wanting to contribute to SciPy
 or just know how current development is going. You can follow
 [our community calendar](https://scientific-python.org/calendars/) from your
 preferred calendar manager, or look out for the announcements on our mailing
-list. 
+list.
 
 ### [SciPy new contributor meetings](https://scientific-python.org/calendars/)
 

--- a/content/en/contribute.md
+++ b/content/en/contribute.md
@@ -16,8 +16,10 @@ issue).
 
 Those are our preferred channels (open source is open by nature).
 
-We also have a biweekly _community call_, details of which are announced on the
-[mailing list](https://mail.python.org/mailman3/lists/scipy-dev.python.org/).
+We also have a biweekly _community call_ and a monthly _new contributors meeting_,
+details of which are announced on the
+[mailing list](https://mail.python.org/mailman3/lists/scipy-dev.python.org/) and
+listed in our [community calendar](https://scientific-python.org/calendars/).
 You are very welcome to join.
 If you are new to contributing to open source, we also highly recommend reading
 [this guide](https://opensource.guide/how-to-contribute/).


### PR DESCRIPTION
Because the link to the calendar is in the text heading, folks might miss it. I've included additional mentions of the calendar link and also added a mention to the new contributor meetings, which were not yet listed on the page.