### PR TITLE
DOC: Add link to slack space

### DIFF
--- a/content/en/community.md
+++ b/content/en/community.md
@@ -44,7 +44,7 @@ On this list please use bottom posting, reply to the list (rather than to
 another sender), and don't reply to digests. A searchable archive of this list
 is available [here](https://mail.python.org/archives/list/scipy-dev@python.org/).
 
-### [SciPy Slack space]
+### [SciPy Slack space](https://join.slack.com/t/scipy-community/shared_invite/zt-1a76bomjr-fuS1ZTnmP7b32kIhLb6QMg)
 
 The SciPy team also has a Slack space that you can join. This is not a user
 support forum, but you can ask questions about contributing and getting involved

--- a/content/en/community.md
+++ b/content/en/community.md
@@ -44,6 +44,12 @@ On this list please use bottom posting, reply to the list (rather than to
 another sender), and don't reply to digests. A searchable archive of this list
 is available [here](https://mail.python.org/archives/list/scipy-dev@python.org/).
 
+### [SciPy Slack space]
+
+The SciPy team also has a Slack space that you can join. This is not a user
+support forum, but you can ask questions about contributing and getting involved
+in the community. To join, please [follow this invite link](https://join.slack.com/t/scipy-community/shared_invite/zt-1a76bomjr-fuS1ZTnmP7b32kIhLb6QMg).
+
 ---
 
 ### [GitHub issue tracker](https://github.com/scipy/scipy/issues)


### PR DESCRIPTION
As discussed in today's community meeting.

A few other details we discussed are already present at the Get Help page (stack overflow, for example) so I didn't add them here.