### PR TITLE
MAINT: Fix broken link in press-kit.md

### DIFF
--- a/content/en/press-kit.md
+++ b/content/en/press-kit.md
@@ -5,4 +5,4 @@ sidebar: false
 
 We would like to make it easy for you to include the SciPy project identity in your next academic paper, course materials, or presentation.
 
-You will find several high-resolution versions of the SciPy logo [here](https://github.com/scipy/scipy/tree/main/branding/logo). Note that by using the scipy.org resources, you accept the [SciPy Code of Conduct](https://docs.scipy.org/doc/scipy/dev/conduct/code_of_conduct.html).
+You will find a high-resolution version of the SciPy logo [here](https://github.com/scipy/scipy.org/blob/main/static/images/logo.svg). Note that by using the scipy.org resources, you accept the [SciPy Code of Conduct](https://docs.scipy.org/doc/scipy/dev/conduct/code_of_conduct.html).


### PR DESCRIPTION
On the `Press Kit` page the link to the logos is invalid.
This PR fixes this link to the `static/images/logo.svg` file.
There are no several logo files anymore, only this single SVG file.