### PR TITLE
Announce SciPy 1.11.1

### DIFF
--- a/content/en/news.md
+++ b/content/en/news.md
@@ -1,9 +1,13 @@
 ---
 title: News
 sidebar: false
-newsHeader: SciPy 1.11.0 released!
-date: 2023-06-25
+newsHeader: SciPy 1.11.1 released!
+date: 2023-06-28
 ---
+
+### SciPy 1.11.1 released
+
+_June 28, 2023_ -- SciPy 1.11.1 has been released!
 
 ### SciPy 1.11.0 released
 
@@ -175,6 +179,7 @@ Here is a list of SciPy releases, with links to release notes. Bugfix
 releases (only the `z` changes in the `x.y.z` version number) have no new
 features; minor releases (the `y` increases) do.
 
+- SciPy 1.11.1 ([release notes](https://github.com/scipy/scipy/releases/tag/v1.11.1)) -- _2023-06-28_.
 - SciPy 1.11.0 ([release notes](https://github.com/scipy/scipy/releases/tag/v1.11.0)) -- _2023-06-25_.
 - SciPy 1.10.1 ([release notes](https://github.com/scipy/scipy/releases/tag/v1.10.1)) -- _2023-02-19_.
 - SciPy 1.10.0 ([release notes](https://github.com/scipy/scipy/releases/tag/v1.10.0)) -- _2023-01-03_.


### PR DESCRIPTION
Announce SciPy `1.11.1`, which was released rapidly to account for a licensing violation in `1.11.0`. The latter release was yanked from PyPI just now.

I did not add any information about the yanking here, but at least it should be clear enough on PyPI.