### PR TITLE
DOC: Fix broken link to dev-build in install.md

### DIFF
--- a/content/en/install.md
+++ b/content/en/install.md
@@ -100,4 +100,4 @@ macOS doesn't have a preinstalled package manager, but you can install
 A word of warning: building SciPy from source can be a nontrivial exercise. We
 recommend using binaries instead if those are available for your platform.
 For details on how to build from source, see
-[this guide in the SciPy docs](https://scipy.github.io/devdocs/dev/contributor/building.html).
+[this guide in the SciPy docs](https://scipy.github.io/devdocs/building/index.html).


### PR DESCRIPTION
#### Reference issue

Addresses part 2/2 in https://github.com/scipy/scipy/issues/18788

#### What does this implement/fix?

Fix the broken (outdated) link to the dev-build guide in install.md.