### PR TITLE
Use dart sass

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,20 @@
 [build.environment]
   PYTHON_VERSION = "3.8" # netlify currently only support 2.7 and 3.8
-  HUGO_VERSION = "0.119.0"
+  HUGO_VERSION = "0.120.3"
+  DART_SASS_VERSION = "1.69.4"
+  DART_SASS_URL = "https://github.com/sass/dart-sass/releases/download/"
+
+[build]
+  base = "/"
+  publish = "public"
+  command = """\
+    export DART_SASS_TARBALL="dart-sass-${DART_SASS_VERSION}-linux-x64.tar.gz" && \
+    curl -LJO ${DART_SASS_URL}/${DART_SASS_VERSION}/${DART_SASS_TARBALL} && \
+    tar -xf ${DART_SASS_TARBALL} && \
+    rm ${DART_SASS_TARBALL} && \
+    export PATH=/opt/build/repo/dart-sass:$PATH && \
+    make html \
+    """
 
 [[redirects]]
   from = "/scipylib"


### PR DESCRIPTION
We need this for recent versions of the theme.

See https://sass-lang.com/blog/libsass-is-deprecated/ and https://gohugo.io/hugo-pipes/transpile-sass-to-css/#dart-sass.