### PR TITLE
Move keyfeatures to a grid of cards

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -49,21 +49,6 @@ languages:
         # Hero image (from static/images/___)
         image: logo.svg
 
-      keyfeatures:
-        features:
-          - title: Fundamental algorithms
-            text: SciPy provides algorithms for optimization, integration, interpolation, eigenvalue problems, algebraic equations, differential equations, statistics and many other classes of problems.
-          - title: Broadly applicable
-            text: The algorithms and data structures provided by SciPy are broadly applicable across domains.
-          - title: Foundational
-            text: Extends NumPy providing additional tools for array computing and provides specialized data structures, such as sparse matrices and k-dimensional trees.
-          - title: Performant
-            text: SciPy wraps highly-optimized implementations written in low-level languages like Fortran, C, and C++. Enjoy the flexibility of Python with the speed of compiled code.
-          - title: Easy to use
-            text: SciPy's high level syntax makes it accessible and productive for programmers from any background or experience level.
-          - title: Open source
-            text: Distributed under a liberal [BSD license](https://github.com/scipy/scipy/blob/main/LICENSE.txt), SciPy is developed and maintained [publicly on GitHub](https://github.com/scipy/scipy) by a vibrant, responsive, and diverse [community](/community).
-
       section5: false
 
       navbar:

--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -1,0 +1,49 @@
+---
+title:
+---
+
+{{< grid columns="1 2 2 3" >}}
+
+{{< card >}}
+title = 'Fundamental algorithms'
+body = '''
+SciPy provides algorithms for optimization, integration, interpolation, eigenvalue problems, algebraic equations, differential equations, statistics and many other classes of problems.
+'''
+{{< /card >}}
+
+{{< card >}}
+title = 'Broadly applicable'
+body = '''
+The algorithms and data structures provided by SciPy are broadly applicable across domains.
+'''
+{{< /card >}}
+
+{{< card >}}
+title = 'Foundational'
+body = '''
+Extends NumPy providing additional tools for array computing and provides specialized data structures, such as sparse matrices and k-dimensional trees.
+'''
+{{< /card >}}
+
+{{< card >}}
+title = 'Performant'
+body = '''
+SciPy wraps highly-optimized implementations written in low-level languages like Fortran, C, and C++. Enjoy the flexibility of Python with the speed of compiled code.
+'''
+{{< /card >}}
+
+{{< card >}}
+title = 'Easy to use'
+body = '''
+SciPy's high level syntax makes it accessible and productive for programmers from any background or experience level.
+'''
+{{< /card >}}
+
+{{< card >}}
+title = 'Open source'
+body = '''
+Distributed under a liberal [BSD license](https://github.com/scipy/scipy/blob/main/LICENSE.txt), SciPy is developed and maintained [publicly on GitHub](https://github.com/scipy/scipy) by a vibrant, responsive, and diverse [community](/community).
+'''
+{{< /card >}}
+
+{{< /grid >}}


### PR DESCRIPTION
Building on functionality from the v0.11 release. The keyfeature panel for the homepage will be removed in a future theme release. This is part of our large effort to adopt styling from pydata-sphinx-theme where possible. It also makes the frontpage behave more like the other pages.

You can see more examples of cards (in a grid) here: 
- https://theme.scientific-python.org/shortcodes/#grid

This will also make it easier to modify your project homepage without having to override `layouts/index.html`.

The styling is a little different than before due to adopting pydata-sphinx-theme styling. But that styling is being used on many community sites and is being reviewed for accessibility.