### PR TITLE
Use new grid syntax

### DIFF
--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -5,8 +5,8 @@ title:
 {{< grid1 columns="1 2 2 3" >}}
 
 [[item]]
-type = 'card
-'title = 'Fundamental algorithms'
+type = 'card'
+title = 'Fundamental algorithms'
 body = '''
 SciPy provides algorithms for optimization, integration, interpolation, eigenvalue problems, algebraic equations, differential equations, statistics and many other classes of problems.
 '''

--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -2,48 +2,48 @@
 title:
 ---
 
-{{< grid columns="1 2 2 3" >}}
+{{< grid1 columns="1 2 2 3" >}}
 
-{{< card >}}
-title = 'Fundamental algorithms'
+[[item]]
+type = 'card
+'title = 'Fundamental algorithms'
 body = '''
 SciPy provides algorithms for optimization, integration, interpolation, eigenvalue problems, algebraic equations, differential equations, statistics and many other classes of problems.
 '''
-{{< /card >}}
 
-{{< card >}}
+[[item]]
+type = 'card'
 title = 'Broadly applicable'
 body = '''
 The algorithms and data structures provided by SciPy are broadly applicable across domains.
 '''
-{{< /card >}}
 
-{{< card >}}
+[[item]]
+type = 'card'
 title = 'Foundational'
 body = '''
 Extends NumPy providing additional tools for array computing and provides specialized data structures, such as sparse matrices and k-dimensional trees.
 '''
-{{< /card >}}
 
-{{< card >}}
+[[item]]
+type = 'card'
 title = 'Performant'
 body = '''
 SciPy wraps highly-optimized implementations written in low-level languages like Fortran, C, and C++. Enjoy the flexibility of Python with the speed of compiled code.
 '''
-{{< /card >}}
 
-{{< card >}}
+[[item]]
+type = 'card'
 title = 'Easy to use'
 body = '''
 SciPy's high level syntax makes it accessible and productive for programmers from any background or experience level.
 '''
-{{< /card >}}
 
-{{< card >}}
+[[item]]
+type = 'card'
 title = 'Open source'
 body = '''
 Distributed under a liberal [BSD license](https://github.com/scipy/scipy/blob/main/LICENSE.txt), SciPy is developed and maintained [publicly on GitHub](https://github.com/scipy/scipy) by a vibrant, responsive, and diverse [community](/community).
 '''
-{{< /card >}}
 
-{{< /grid >}}
+{{< /grid1 >}}


### PR DESCRIPTION
Switching to the new grid syntax.

v0.13
- add new syntax via grid1 to theme
- port website to grid1

v0.14
- cp grid1 to grid in theme
- replace grid1 with grid in websites

v0.15
- rm grid1 from theme
- nothing to do for websites