### PR TITLE
Loosen pre-commit pin

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-pre-commit==3.5.0
+pre-commit>=3.5.0


### PR DESCRIPTION
Close #563. Need a version that supports Python 3.9 (version on netlify). Specifying `pre-commit>=3.5.0` will prevent dependabot from trying to update it.