### PR TITLE
Announce SciPy 1.13.1

### DIFF
--- a/content/en/news.md
+++ b/content/en/news.md
@@ -1,9 +1,13 @@
 ---
 title: News
 sidebar: false
-newsHeader: SciPy 1.13.0 released!
-date: 2024-04-02
+newsHeader: SciPy 1.13.1 released!
+date: 2024-05-22
 ---
+
+### SciPy 1.13.1 released
+
+_May 22, 2024_ -- SciPy 1.13.1 has been released!
 
 ### SciPy 1.13.0 released
 
@@ -201,6 +205,7 @@ Here is a list of SciPy releases, with links to release notes. Bugfix
 releases (only the `z` changes in the `x.y.z` version number) have no new
 features; minor releases (the `y` increases) do.
 
+- SciPy 1.13.1 ([release notes](https://github.com/scipy/scipy/releases/tag/v1.13.1)) -- _2024-05-22_.
 - SciPy 1.13.0 ([release notes](https://github.com/scipy/scipy/releases/tag/v1.13.0)) -- _2024-04-02_.
 - SciPy 1.12.0 ([release notes](https://github.com/scipy/scipy/releases/tag/v1.12.0)) -- _2024-01-20_.
 - SciPy 1.11.4 ([release notes](https://github.com/scipy/scipy/releases/tag/v1.11.4)) -- _2023-11-18_.


### PR DESCRIPTION
Announce SciPy `1.13.1`.

The final few steps of the release process, like docs upload and so on, will have to wait until tomorrow, it is late.