### PR TITLE
Update installation page

### DIFF
--- a/content/en/beginner-install.md
+++ b/content/en/beginner-install.md
@@ -45,10 +45,10 @@ Other options include:
   and the IEP interactive development environment; Supports Linux,
   Windows, and Mac.
 
+{{< admonition note >}}
 Users in large, non-university institutions may want to read Anaconda's
-helpful blog on ["when is Anaconda free to use?"][anaconda-blog]
-
-[anaconda-blog]: https://www.anaconda.com/blog/update-on-anacondas-terms-of-service-for-academia-and-research
+helpful blog on ["when is Anaconda free to use?"](https://www.anaconda.com/blog/update-on-anacondas-terms-of-service-for-academia-and-research)
+{{< /admonition >}}
 
 After installing a scientific Python distribution,
 see next steps in [the SciPy user guide][scipy-user-guide].

--- a/content/en/beginner-install.md
+++ b/content/en/beginner-install.md
@@ -1,0 +1,70 @@
+---
+title: Beginner Installation Guide
+sidebar: false
+---
+
+{{< admonition tip >}}
+This is the beginner installation guide.
+If you are comfortable with using a terminal and happy to learn
+how to use a package manager, check out 
+[the main installation guide](./install.md)!
+{{< /admonition >}}
+
+- [JupyterLite](#jupyterlite)
+- [Scientific Python Distributions](#distributions)
+- [Installing globally with `pip`](#pip-global)
+
+<a name="jupyterlite"></a>
+
+## JupyterLite
+
+To try out SciPy, you don't even need to install it!
+You can use SciPy in your browser at https://jupyter.org/try-jupyter/lab/ -
+just write `import scipy` in one of the notebook "cells" and hit play.
+
+For next steps, see [the SciPy user guide][scipy-user-guide].
+
+<a name="distributions"></a>
+
+## Scientific Python Distributions
+
+Python distributions provide the language itself, along with the most
+commonly used packages and tools. These downloadable files require
+little configuration, work on almost all setups, and provide all the
+most commonly used scientific Python tools.
+[Anaconda](https://www.anaconda.com/download/) works on Windows, Mac,
+and Linux, and is best suited to beginning users.
+Other options include:
+- [WinPython](https://winpython.github.io): Another free distribution
+  including scientific packages and the Spyder IDE; Windows only, but
+  more actively maintained and supports the latest Python 3 versions.
+- [Pyzo](https://pyzo.org): A free distribution based on Anaconda
+  and the IEP interactive development environment; Supports Linux,
+  Windows, and Mac.
+
+Users in large, non-university institutions may want to read Anaconda's
+helpful blog on ["when is Anaconda free to use?"][anaconda-blog]
+
+[anaconda-blog]: https://www.anaconda.com/blog/update-on-anacondas-terms-of-service-for-academia-and-research
+
+After installing a scientific Python distribution,
+see next steps in [the SciPy user guide][scipy-user-guide].
+
+<a name="pip-global"></a>
+
+## Installing globally with `pip`
+
+If you already have Python installed, you can install SciPy globally
+with `pip` by executing the following in a terminal/shell:
+
+    python -m pip install scipy
+
+You may see this recommended in tutorials or classes, but it is not
+recommended to install packages globally on your system.
+The recommended way to install SciPy with `pip` is to use a virtual
+environment - see [Installing with `pip`](./install.md#installing-with-pip).
+
+{{< admonition note >}}
+For more information on why this is not a recommended installation method,
+read about [virtual environments in the Python Packaging User Guide](https://packaging.python.org/en/latest/tutorials/installing-packages/#creating-virtual-environments).
+{{< /admonition >}}

--- a/content/en/beginner-install.md
+++ b/content/en/beginner-install.md
@@ -62,10 +62,12 @@ with `pip` by executing the following in a terminal/shell:
 
     python -m pip install scipy
 
+{{< admonition warning >}}
 You may see this recommended in tutorials or classes, but it is not
 recommended to install packages globally on your system.
 The recommended way to install SciPy with `pip` is to use a virtual
 environment - see [Installing with `pip`](./install.md#installing-with-pip).
+{{< /admonition >}}
 
 {{< admonition note >}}
 For more information on why this is not a recommended installation method,

--- a/content/en/beginner-install.md
+++ b/content/en/beginner-install.md
@@ -20,7 +20,8 @@ how to use a package manager, check out
 
 To try out SciPy, you don't even need to install it!
 You can use SciPy in your browser at https://jupyter.org/try-jupyter/lab/ -
-just write `import scipy` in one of the notebook "cells" and hit play.
+just open a Python Notebook, then write `import scipy` in one of
+the notebook "cells" and hit play.
 
 For next steps, see [the SciPy user guide][scipy-user-guide].
 
@@ -46,8 +47,9 @@ Other options include:
   Windows, and Mac.
 
 {{< admonition note >}}
-Users in large, non-university institutions may want to read Anaconda's
-helpful blog on ["when is Anaconda free to use?"](https://www.anaconda.com/blog/update-on-anacondas-terms-of-service-for-academia-and-research)
+Anaconda is free to use for inviduals, universities, and companies smaller than
+200 employees. For more detail, see Anaconda's helpful blog on
+["when is Anaconda free to use?"](https://www.anaconda.com/blog/update-on-anacondas-terms-of-service-for-academia-and-research)
 {{< /admonition >}}
 
 After installing a scientific Python distribution,
@@ -58,6 +60,7 @@ see next steps in [the SciPy user guide][scipy-user-guide].
 ## Installing globally with `pip`
 
 If you already have Python installed, you can install SciPy globally
+(for all users on the system)
 with `pip` by executing the following in a terminal/shell:
 
     python -m pip install scipy

--- a/content/en/beginner-install.md
+++ b/content/en/beginner-install.md
@@ -6,7 +6,7 @@ sidebar: false
 {{< admonition tip >}}
 This is the beginner installation guide.
 If you are comfortable with using a terminal and happy to learn
-how to use a package manager, check out 
+how to use a package manager, check out
 [the main installation guide](./install.md)!
 {{< /admonition >}}
 
@@ -35,6 +35,7 @@ most commonly used scientific Python tools.
 [Anaconda](https://www.anaconda.com/download/) works on Windows, Mac,
 and Linux, and is best suited to beginning users.
 Other options include:
+
 - [WinPython](https://winpython.github.io): Another free distribution
   including scientific packages and the Spyder IDE; Windows only, but
   more actively maintained and supports the latest Python 3 versions.

--- a/content/en/beginner-install.md
+++ b/content/en/beginner-install.md
@@ -40,8 +40,7 @@ and Linux, and is best suited to beginning users.
 Other options include:
 
 - [WinPython](https://winpython.github.io): Another free distribution
-  including scientific packages and the Spyder IDE; Windows only, but
-  more actively maintained and supports the latest Python 3 versions.
+  including scientific packages and the Spyder IDE; Windows only.
 - [Pyzo](https://pyzo.org): A free distribution based on Anaconda
   and the IEP interactive development environment; Supports Linux,
   Windows, and Mac.
@@ -59,8 +58,7 @@ see next steps in [the SciPy user guide][scipy-user-guide].
 
 ## Installing globally with `pip`
 
-If you already have Python installed, you can install SciPy globally
-(for all users on the system)
+If you already have Python installed, you can install SciPy
 with `pip` by executing the following in a terminal/shell:
 
     python -m pip install scipy

--- a/content/en/beginner-install.md
+++ b/content/en/beginner-install.md
@@ -64,10 +64,9 @@ with `pip` by executing the following in a terminal/shell:
     python -m pip install scipy
 
 {{< admonition warning >}}
-You may see this recommended in tutorials or classes, but it is not
-recommended to install packages globally on your system.
-The recommended way to install SciPy with `pip` is to use a virtual
-environment - see [Installing with `pip`](./install.md#installing-with-pip).
+You may see this recommended in tutorials or classes, but the recommended
+way to install SciPy with `pip` is to use a virtual environment -
+see [Installing with `pip`](./install.md#installing-with-pip).
 {{< /admonition >}}
 
 {{< admonition note >}}

--- a/content/en/beginner-install.md
+++ b/content/en/beginner-install.md
@@ -24,6 +24,8 @@ just write `import scipy` in one of the notebook "cells" and hit play.
 
 For next steps, see [the SciPy user guide][scipy-user-guide].
 
+[scipy-user-guide]: https://docs.scipy.org/doc/scipy/tutorial/
+
 <a name="distributions"></a>
 
 ## Scientific Python Distributions

--- a/content/en/install.md
+++ b/content/en/install.md
@@ -46,7 +46,7 @@ a Python package manager.
         cd try-scipy
 
     {{< admonition hint >}}
-    The second command changes directory into the directory of your project.
+The second command changes directory into the directory of your project.
     {{< /admonition >}}
 
 3.  Install Python:
@@ -54,7 +54,7 @@ a Python package manager.
         uv python install
 
     {{< admonition note >}}
-    If you have already installed Python, this step is optional.
+If you have already installed Python, this step is optional.
     {{< /admonition >}}
 
 4.  Add SciPy to your project:
@@ -101,7 +101,7 @@ tool [`pixi`] are very similar to the steps for `uv`:
         uv add scipy
 
     {{< admonition note >}}
-    This step also adds Python from conda-forge.
+This step also adds Python from conda-forge.
     {{< /admonition >}}
 
 4.  Try out SciPy!
@@ -126,7 +126,7 @@ but lack some reproducibility benefits of project-based workflows.
 2. Create and activate a virtual environment with `venv`.
 
    {{< admonition hint >}}
-   See [the tutorial in the Python Packaging User Guide][venv-guide].
+See [the tutorial in the Python Packaging User Guide][venv-guide].
    {{< /admonition >}}
 
 [venv-guide]: https://packaging.python.org/en/latest/tutorials/installing-packages/#creating-virtual-environments

--- a/content/en/install.md
+++ b/content/en/install.md
@@ -126,10 +126,8 @@ but lack some reproducibility benefits of project-based workflows.
 2. Create and activate a virtual environment with `venv`.
 
    {{< admonition hint >}}
-See [the tutorial in the Python Packaging User Guide][venv-guide].
+See [the tutorial in the Python Packaging User Guide](https://packaging.python.org/en/latest/tutorials/installing-packages/#creating-virtual-environments).
    {{< /admonition >}}
-
-[venv-guide]: https://packaging.python.org/en/latest/tutorials/installing-packages/#creating-virtual-environments
 
 3.  Install SciPy, using [`pip`]:
 

--- a/content/en/install.md
+++ b/content/en/install.md
@@ -3,125 +3,89 @@ title: Installation
 sidebar: false
 ---
 
-Installation methods include:
+The recommended method of installing SciPy depends on your preferred workflow.
+The common workflows can roughly be broken down into the following
+categories:
 
-- [Python Distributions](#distributions)
-- [PyPI (`pip`, `uv`)](#pypi-install)
-- [conda-forge (`conda`, `mamba`, `pixi`)](#conda-forge-install)
-- [System Package Managers](#system-package-manager)
-- [Source](#source)
-
-Methods differ in ease of use, coverage, maintenance of old versions,
-system-wide versus local environment use, and control. When installing
-from PyPI or with Conda, you can control the package versions for a specific
-project to prevent conflicts. Conda also controls non-Python packages,
-like MKL or HDF5. System package managers, like `apt-get`, install
-across the entire computer, often have older versions, and don't have
-as many available versions. Source compilation is much more difficult
-but is necessary for debugging and development. If you don't know which
-installation method you need or prefer, we recommend the Scientific
-Python Distribution [Anaconda](https://www.anaconda.com/download/).
-
-Users in large, non-university institutions may want to read Anaconda's
-helpful blog on ["when is Anaconda free to use?"][anaconda-blog]
-
-[anaconda-blog]: https://www.anaconda.com/blog/update-on-anacondas-terms-of-service-for-academia-and-research
+- [Environment-based (e.g. `pip`, `conda`)](#environment-based) (the traditional workflow)
+- [Project-based (e.g. `uv`, `pixi`)](#project-based) (recommended for new users)
+- [System package managers](#system-package-managers) (simplest)
+- [Building from source](#building-from-source) (for debugging and development)
 
 To install SciPy with [static type stubs],
 see [Installing with type stubs](#type-stubs).
 
 [static type stubs]: https://typing.readthedocs.io/en/latest/guides/libraries.html
 
-<a name="distributions"></a>
+<a name="environment-based"></a>
 
-## Scientific Python Distributions (recommended for new users)
+## Environment-based workflows
 
-Python distributions provide the language itself, along with the most
-commonly used packages and tools. These downloadable files require
-little configuration, work on almost all setups, and provide all the
-commonly used scientific Python tools.
+In environment-based workflows, you install packages into an environment, which you
+can activate and deactivate.
 
-[Anaconda](https://www.anaconda.com/download/) works on Windows, Mac,
-and Linux, provides over 1,500 Python packages, and is used by over 15
-million people. Anaconda is best suited to beginning users; it provides
-a large collection of libraries all in one.
-
-Other options include:
-
-- [WinPython](https://winpython.github.io): Another free distribution
-  including scientific packages and the Spyder IDE; Windows only, but
-  more actively maintained and supports the latest Python 3 versions.
-- [Pyzo](https://pyzo.org): A free distribution based on Anaconda
-  and the IEP interactive development environment; Supports Linux,
-  Windows, and Mac.
-
-If you already have Python installed, you can
-[install SciPy with `pip`](#pip-install).
-For more advanced users who will need to install or upgrade regularly,
-you may prefer to use a dedicated package manager like [`uv`]
-(see [Installing with `uv`](#uv-install)),
-[Conda], or [`pixi`] (see [Installing from conda-forge](#conda-forge-install)).
-
-[`uv`]: https://docs.astral.sh/uv/
-[Conda]: https://docs.conda.io/projects/conda/en/latest/index.html
-[`pixi`]: https://pixi.sh/latest/
-
-<a name="pypi-install"></a>
-
-## Installing from PyPI
-
-SciPy is [available on PyPI](https://pypi.org/project/scipy/), the Python Package Index.
-
-<a name="pip-install"></a>
-
-### Installing with `pip`
-
-You can install SciPy from PyPI with `pip`:
+If you have installed Python, you can create a virtual environment with a tool such
+as `venv` - see [the tutorial in the Python Packaging User Guide][venv-guide].
+You can then install [SciPy from PyPI], the Python Package Index, with [`pip`]:
 
     python -m pip install scipy
 
-<a name="uv-install"></a>
+[venv-guide]: https://packaging.python.org/en/latest/tutorials/installing-packages/#creating-virtual-environments
+[SciPy from PyPI]: https://pypi.org/project/scipy/
+[`pip`]: https://pip.pypa.io/en/stable/getting-started/
 
-### Installing with `uv`
+Alternatively, you can install [SciPy from conda-forge] using a [Conda]-based
+environment manager. You can install Python itself, as well as packages in
+languages other than Python, as Conda packages.
 
-You can also add SciPy from PyPI to a `uv` project:
+[Miniforge] is the recommended way to install `conda` and [`mamba`],
+two Conda-based environment managers. You can then install SciPy as follows:
+
+    conda install scipy # or
+    mamba install scipy
+
+[SciPy from conda-forge]: https://anaconda.org/conda-forge/scipy
+[Miniforge]: https://conda-forge.org/download/
+[Conda]: https://docs.conda.io/projects/conda/en/latest/index.html
+[`mamba`]: https://mamba.readthedocs.io/en/latest/
+
+<a name="project-based"></a>
+
+## Project-based workflows
+
+In project-based workflows, a project is a directory containing a manifest
+file describing the project, a lock-file describing the exact dependencies
+of the project, and the project's (potentially multiple) environments.
+These workflows provide reproducibility benefits over environment-based workflows.
+
+You can add [SciPy from PyPI] to a [`uv`] project:
 
     uv add scipy
 
-<a name="conda-forge-install"></a>
+You can also install Python itself with `uv`.
 
-## Installing from conda-forge
+[`uv`]: https://docs.astral.sh/uv/
 
-### Installing with `conda` or `mamba`
+If you work with non-Python packages, you may prefer to install SciPy as
+a Conda package, so that you can use the same workflow for packages which
+are not available on PyPI.
 
-[`Miniforge`] is the recommended way to install the `conda`
-(and `mamba`, a faster `conda` alternative) package manager.
-You can then install SciPy as follows:
-
-    mamba install scipy
-
-[`Miniforge`]: https://conda-forge.org/download/
-
-### Installing with `pixi`
-
-You can also add SciPy from conda-forge to a [`pixi`] project:
+You can add [SciPy from conda-forge] to a [`pixi`] project:
 
     pixi add scipy
 
-## Installing from the Anaconda Repository
+Pixi can also install packages from PyPI, using `uv` under the hood.
 
-If you instead install `conda` via [`Miniconda`], you can install
-[SciPy from the Anaconda repository](https://anaconda.org/anaconda/scipy):
+[`pixi`]: https://pixi.sh/latest/
 
-    conda install scipy
+<a name="system-package-managers"></a>
 
-<a name="system-package-manager"></a>
-
-## Install system-wide via a system package manager
+## Installing system-wide via a system package manager
 
 System package managers can install the most common Python packages.
 They install packages for the entire computer, often use older versions,
-and don't have as many available versions.
+and don't have as many available versions. They are not the recommended
+installation method, but they are the simplest.
 
 ### Ubuntu and Debian
 
@@ -142,14 +106,16 @@ macOS doesn't have a preinstalled package manager, but you can install
 
     brew install scipy
 
-<a name="source"></a>
+<a name="building-from-source"></a>
 
-## Source packages
+## Building from source
 
 A word of warning: building SciPy from source can be a nontrivial exercise. We
 recommend using binaries instead if those are available for your platform.
 For details on how to build from source, see
-[this guide in the SciPy docs](https://scipy.github.io/devdocs/building/index.html).
+[the building from source guide in the SciPy docs][building-docs].
+
+[building-docs]: https://scipy.github.io/devdocs/building/index.html
 
 <a name="type-stubs"></a>
 
@@ -161,7 +127,7 @@ install `scipy-stubs` in the same way:
 
     python -m pip install scipy-stubs # or
     uv add scipy-stubs # or
-    mamba install scipy-stubs # or
+    conda install scipy-stubs # or
     pixi add scipy-stubs
 
 <!---
@@ -174,8 +140,11 @@ package on conda-forge.
 To get a specific version `x.y.z` of SciPy (such as `1.14.1`),
 you should install version `x.y.z.*` below:
 
-    python -m pip install 'scipy-stubs[scipy]' # or
+    python -m pip install "scipy-stubs[scipy]" # or
     # versions for illustrative purposes
-    uv add 'scipy-stubs[scipy]==1.14.*' # or
-    mamba install 'scipy-typed==1.14.1.*' # or
-    pixi add 'scipy-typed==1.15.0.*'
+    uv add "scipy-stubs[scipy]==1.14.1.*" # or
+    conda install "scipy-typed>=1.14" # or
+    pixi add "scipy-typed=1.15.0.*"
+
+Please direct questions about static typing support to
+[the `scipy-stubs` repo](https://github.com/jorenham/scipy-stubs).

--- a/content/en/install.md
+++ b/content/en/install.md
@@ -70,9 +70,7 @@ you may prefer to use a dedicated package manager like [`uv`]
 
 # Installing from PyPI
 
-SciPy is [available on PyPI](PyPI-scipy), the Python Package Index.
-
-[PyPI-scipy]: https://pypi.org/project/scipy/
+SciPy is [available on PyPI](https://pypi.org/project/scipy/), the Python Package Index.
 
 <a name="pip-install"></a>
 

--- a/content/en/install.md
+++ b/content/en/install.md
@@ -35,6 +35,8 @@ a Python package manager.
 
 [`uv`]: https://docs.astral.sh/uv/
 
+<!-- prettier-ignore-start -->
+
 1. Install `uv`, following [the instructions in the `uv` documentation][install-uv].
 
 [install-uv]: https://docs.astral.sh/uv/getting-started/installation/
@@ -56,18 +58,20 @@ The second command changes directory into the directory of your project.
 This will automatically install Python if you don't already have it installed!
     {{< /admonition >}}
 
-{{< admonition tip >}}
+    {{< admonition tip >}}
 You can install other Python libraries in the same way, e.g.
 
     uv add matplotlib
 
-{{< /admonition >}}
+    {{< /admonition >}}
 
 4.  Try out SciPy!
 
         uv run python
 
     This will launch a Python interpreter session, from which you can `import scipy`.
+
+<!-- prettier-ignore-end -->
 
 See next steps in [the SciPy user guide][scipy-user-guide].
 
@@ -137,6 +141,8 @@ but lack some reproducibility benefits of project-based workflows.
 
 ### Installing with `pip`
 
+<!-- prettier-ignore-start -->
+
 1.  [Install Python](https://www.python.org/downloads/).
 
 2.  Create and activate a virtual environment with `venv`.
@@ -148,6 +154,8 @@ See [the tutorial in the Python Packaging User Guide](https://packaging.python.o
 3.  Install SciPy, using [`pip`]:
 
         python -m pip install scipy
+
+<!-- prettier-ignore-end -->
 
 [`pip`]: https://pip.pypa.io/en/stable/getting-started/
 

--- a/content/en/install.md
+++ b/content/en/install.md
@@ -53,7 +53,7 @@ The second command changes directory into the directory of your project.
 This will automatically install Python if you don't already have it installed!
     {{< /admonition >}}
 
-{{< admonition note >}}
+{{< admonition tip >}}
 You can install other Python libraries in the same way, e.g.
 
     uv add matplotlib

--- a/content/en/install.md
+++ b/content/en/install.md
@@ -40,7 +40,7 @@ a Python package manager.
 
 [install-uv]: https://docs.astral.sh/uv/getting-started/installation/
 
-2. Create a new project in a new subdirectory, by executing the following in a terminal:
+2.  Create a new project in a new subdirectory, by executing the following in a terminal:
 
         uv init try-scipy
         cd try-scipy
@@ -49,7 +49,7 @@ a Python package manager.
     The second command changes directory into the directory of your project.
     {{< /admonition >}}
 
-3. Install Python:
+3.  Install Python:
 
         uv python install
 
@@ -57,11 +57,11 @@ a Python package manager.
     If you have already installed Python, this step is optional.
     {{< /admonition >}}
 
-4. Add SciPy to your project:
+4.  Add SciPy to your project:
 
         uv add scipy
 
-5. Try out SciPy!
+5.  Try out SciPy!
 
         uv run python
 
@@ -91,12 +91,12 @@ tool [`pixi`] are very similar to the steps for `uv`:
 
 [install-pixi]: https://pixi.sh/latest/
 
-2. Create a new project in a new subdirectory:
+2.  Create a new project in a new subdirectory:
 
         pixi init try-scipy
         cd try-scipy
 
-4. Add SciPy to your project:
+3.  Add SciPy to your project:
 
         uv add scipy
 
@@ -104,7 +104,7 @@ tool [`pixi`] are very similar to the steps for `uv`:
     This step also adds Python from conda-forge.
     {{< /admonition >}}
 
-5. Try out SciPy!
+4.  Try out SciPy!
 
         pixi run python
 
@@ -125,13 +125,13 @@ but lack some reproducibility benefits of project-based workflows.
 
 2. Create and activate a virtual environment with `venv`.
 
-    {{< admonition hint >}}
-    See [the tutorial in the Python Packaging User Guide][venv-guide].
-    {{< /admonition >}}
+   {{< admonition hint >}}
+   See [the tutorial in the Python Packaging User Guide][venv-guide].
+   {{< /admonition >}}
 
 [venv-guide]: https://packaging.python.org/en/latest/tutorials/installing-packages/#creating-virtual-environments
 
-3. Install SciPy, using [`pip`]:
+3.  Install SciPy, using [`pip`]:
 
         python -m pip install scipy
 

--- a/content/en/install.md
+++ b/content/en/install.md
@@ -3,6 +3,13 @@ title: Installation
 sidebar: false
 ---
 
+{{< admonition tip >}}
+This page assumes that you are comfortable with using a terminal and happy to learn
+how to use a package manager. If you are a beginner and just want to get started
+with SciPy as quickly as possible, check out
+[the beginner installation guide](./beginner-install.md)!
+{{< /admonition >}}
+
 The recommended method of installing SciPy depends on your preferred workflow.
 The common workflows can roughly be broken down into the following
 categories:
@@ -23,11 +30,7 @@ see [Installing with type stubs](#type-stubs).
 
 ### Installing with `uv`
 
-{{< admonition tip >}}
-If it is your first time installing a Python library, start here!
-{{< /admonition >}}
-
-Here is a step-by-step guide to setting up a project to try SciPy, with [`uv`],
+Here is a step-by-step guide to setting up a project to use SciPy, with [`uv`],
 a Python package manager.
 
 [`uv`]: https://docs.astral.sh/uv/
@@ -69,6 +72,19 @@ You can install other Python libraries in the same way, e.g.
 See next steps in [the SciPy user guide][scipy-user-guide].
 
 [scipy-user-guide]: https://docs.scipy.org/doc/scipy/tutorial/
+
+{{< admonition note >}}
+
+After rebooting your computer, you'll want to navigate to your `try-scipy`
+project directory and execute `uv run python` to drop back into a Python interpreter
+with SciPy importable.
+To execute a Python script, you can use `uv run myscript.py`.
+
+Read more at [the uv guide to working on projects][uv-projects].
+
+[uv-projects]: https://docs.astral.sh/uv/guides/projects/
+
+{{< /admonition >}}
 
 ### Installing with `pixi`
 

--- a/content/en/install.md
+++ b/content/en/install.md
@@ -147,4 +147,4 @@ you should install version `x.y.z.*` below:
     pixi add "scipy-typed=1.15.0.*"
 
 Please direct questions about static typing support to
-[the `scipy-stubs` repo](https://github.com/jorenham/scipy-stubs).
+[the `scipy-stubs` GitHub repository](https://github.com/jorenham/scipy-stubs).

--- a/content/en/install.md
+++ b/content/en/install.md
@@ -98,7 +98,7 @@ tool [`pixi`] are very similar to the steps for `uv`:
 
 3.  Add SciPy to your project:
 
-        uv add scipy
+        pixi add scipy
 
     {{< admonition note >}}
 This step also adds Python from conda-forge.

--- a/content/en/install.md
+++ b/content/en/install.md
@@ -179,4 +179,3 @@ you should install version `x.y.z.*` below:
     uv add 'scipy-stubs[scipy]==1.14.*' # or
     mamba install 'scipy-typed==1.14.1.*' # or
     pixi add 'scipy-typed==1.15.0.*'
-

--- a/content/en/install.md
+++ b/content/en/install.md
@@ -111,7 +111,8 @@ macOS doesn't have a preinstalled package manager, but you can install
 ## Building from source
 
 A word of warning: building SciPy from source can be a nontrivial exercise. We
-recommend using binaries instead if those are available for your platform.
+recommend using binaries instead if those are available for your platform
+via one of the above methods.
 For details on how to build from source, see
 [the building from source guide in the SciPy docs][building-docs].
 

--- a/content/en/install.md
+++ b/content/en/install.md
@@ -34,7 +34,7 @@ see [Installing with type stubs](#type-stubs).
 
 <a name="distributions"></a>
 
-# Scientific Python Distributions (recommended for new users)
+## Scientific Python Distributions (recommended for new users)
 
 Python distributions provide the language itself, along with the most
 commonly used packages and tools. These downloadable files require
@@ -68,13 +68,13 @@ you may prefer to use a dedicated package manager like [`uv`]
 
 <a name="pypi-install"></a>
 
-# Installing from PyPI
+## Installing from PyPI
 
 SciPy is [available on PyPI](https://pypi.org/project/scipy/), the Python Package Index.
 
 <a name="pip-install"></a>
 
-## Installing with `pip`
+### Installing with `pip`
 
 You can install SciPy from PyPI with `pip`:
 
@@ -82,7 +82,7 @@ You can install SciPy from PyPI with `pip`:
 
 <a name="uv-install"></a>
 
-## Installing with `uv`
+### Installing with `uv`
 
 You can also add SciPy from PyPI to a `uv` project:
 
@@ -90,9 +90,9 @@ You can also add SciPy from PyPI to a `uv` project:
 
 <a name="conda-forge-install"></a>
 
-# Installing from conda-forge
+## Installing from conda-forge
 
-## Installing with `conda` or `mamba`
+### Installing with `conda` or `mamba`
 
 [`Miniforge`] is the recommended way to install the `conda`
 (and `mamba`, a faster `conda` alternative) package manager.
@@ -102,13 +102,13 @@ You can then install SciPy as follows:
 
 [`Miniforge`]: https://conda-forge.org/download/
 
-## Installing with `pixi`
+### Installing with `pixi`
 
 You can also add SciPy from conda-forge to a [`pixi`] project:
 
     pixi add scipy
 
-# Installing from the Anaconda Repository
+## Installing from the Anaconda Repository
 
 If you instead install `conda` via [`Miniconda`], you can install
 [SciPy from the Anaconda repository](https://anaconda.org/anaconda/scipy):
@@ -117,25 +117,25 @@ If you instead install `conda` via [`Miniconda`], you can install
 
 <a name="system-package-manager"></a>
 
-# Install system-wide via a system package manager
+## Install system-wide via a system package manager
 
 System package managers can install the most common Python packages.
 They install packages for the entire computer, often use older versions,
 and don't have as many available versions.
 
-## Ubuntu and Debian
+### Ubuntu and Debian
 
 Using `apt-get`:
 
     sudo apt-get install python3-scipy
 
-## Fedora
+### Fedora
 
 Using `dnf`:
 
     sudo dnf install python3-scipy
 
-## macOS
+### macOS
 
 macOS doesn't have a preinstalled package manager, but you can install
 [Homebrew](https://brew.sh/) and use it to install SciPy (and Python itself):
@@ -144,7 +144,7 @@ macOS doesn't have a preinstalled package manager, but you can install
 
 <a name="source"></a>
 
-# Source packages
+## Source packages
 
 A word of warning: building SciPy from source can be a nontrivial exercise. We
 recommend using binaries instead if those are available for your platform.
@@ -153,7 +153,7 @@ For details on how to build from source, see
 
 <a name="type-stubs"></a>
 
-# Installing with type stubs
+## Installing with type stubs
 
 Static type stubs are available via a separate package, `scipy-stubs`, on
 PyPI and conda-forge. If you have already installed SciPy, you just need to

--- a/content/en/install.md
+++ b/content/en/install.md
@@ -7,47 +7,15 @@ The recommended method of installing SciPy depends on your preferred workflow.
 The common workflows can roughly be broken down into the following
 categories:
 
-- [Environment-based (e.g. `pip`, `conda`)](#environment-based) (the traditional workflow)
 - [Project-based (e.g. `uv`, `pixi`)](#project-based) (recommended for new users)
-- [System package managers](#system-package-managers) (simplest)
+- [Environment-based (e.g. `pip`, `conda`)](#environment-based) (the traditional workflow)
+- [System package managers](#system-package-managers) (not recommended)
 - [Building from source](#building-from-source) (for debugging and development)
 
 To install SciPy with [static type stubs],
 see [Installing with type stubs](#type-stubs).
 
 [static type stubs]: https://typing.readthedocs.io/en/latest/guides/libraries.html
-
-<a name="environment-based"></a>
-
-## Environment-based workflows
-
-In environment-based workflows, you install packages into an environment, which you
-can activate and deactivate.
-
-If you have installed Python, you can create a virtual environment with a tool such
-as `venv` - see [the tutorial in the Python Packaging User Guide][venv-guide].
-You can then install [SciPy from PyPI], the Python Package Index, with [`pip`]:
-
-    python -m pip install scipy
-
-[venv-guide]: https://packaging.python.org/en/latest/tutorials/installing-packages/#creating-virtual-environments
-[SciPy from PyPI]: https://pypi.org/project/scipy/
-[`pip`]: https://pip.pypa.io/en/stable/getting-started/
-
-Alternatively, you can install [SciPy from conda-forge] using a [Conda]-based
-environment manager. You can install Python itself, as well as packages in
-languages other than Python, as Conda packages.
-
-[Miniforge] is the recommended way to install `conda` and [`mamba`],
-two Conda-based environment managers. You can then install SciPy as follows:
-
-    conda install scipy # or
-    mamba install scipy
-
-[SciPy from conda-forge]: https://anaconda.org/conda-forge/scipy
-[Miniforge]: https://conda-forge.org/download/
-[Conda]: https://docs.conda.io/projects/conda/en/latest/index.html
-[`mamba`]: https://mamba.readthedocs.io/en/latest/
 
 <a name="project-based"></a>
 
@@ -56,27 +24,130 @@ two Conda-based environment managers. You can then install SciPy as follows:
 In project-based workflows, a project is a directory containing a manifest
 file describing the project, a lock-file describing the exact dependencies
 of the project, and the project's (potentially multiple) environments.
-These workflows provide reproducibility benefits over environment-based workflows.
 
-You can add [SciPy from PyPI] to a [`uv`] project:
+### Installing with `uv`
 
-    uv add scipy
+{{< admonition tip >}}
+If it is your first time installing a Python library, start here!
+{{< /admonition >}}
 
-You can also install Python itself with `uv`.
+Here is a step-by-step guide to setting up a project to try SciPy with [`uv`],
+a Python package manager.
 
 [`uv`]: https://docs.astral.sh/uv/
 
+1. Install `uv`, following [the instructions in the `uv` documentation][install-uv].
+
+[install-uv]: https://docs.astral.sh/uv/getting-started/installation/
+
+2. Create a new project in a new subdirectory, by executing the following in a terminal:
+
+        uv init try-scipy
+        cd try-scipy
+
+    {{< admonition hint >}}
+    The second command changes directory into the directory of your project.
+    {{< /admonition >}}
+
+3. Install Python:
+
+        uv python install
+
+    {{< admonition note >}}
+    If you have already installed Python, this step is optional.
+    {{< /admonition >}}
+
+4. Add SciPy to your project:
+
+        uv add scipy
+
+5. Try out SciPy!
+
+        uv run python
+
+    This will launch a Python interpreter session, from which you can `import scipy`.
+
+See next steps in [the SciPy user guide][scipy-user-guide].
+
+[scipy-user-guide]: https://docs.scipy.org/doc/scipy/tutorial/
+
+### Installing with `pixi`
+
 If you work with non-Python packages, you may prefer to install SciPy as
-a Conda package, so that you can use the same workflow for packages which
-are not available on PyPI.
+a [Conda] package, so that you can use the same workflow for packages which
+are not available on [PyPI](https://pypi.org/), the Python Package Index.
+Conda can manage packages in any language, so you can use it to install
+Python itself, compilers, and other languages.
 
-You can add [SciPy from conda-forge] to a [`pixi`] project:
+[Conda]: https://docs.conda.io/projects/conda/en/latest/index.html
 
-    pixi add scipy
+The steps to install SciPy from [conda-forge] using the package management
+tool [`pixi`] are very similar to the steps for `uv`:
 
-Pixi can also install packages from PyPI, using `uv` under the hood.
-
+[conda-forge]: https://conda-forge.org/
 [`pixi`]: https://pixi.sh/latest/
+
+1. Install `pixi`, following [the instructions in the `pixi` documentation][install-pixi].
+
+[install-pixi]: https://pixi.sh/latest/
+
+2. Create a new project in a new subdirectory:
+
+        pixi init try-scipy
+        cd try-scipy
+
+4. Add SciPy to your project:
+
+        uv add scipy
+
+    {{< admonition note >}}
+    This step also adds Python from conda-forge.
+    {{< /admonition >}}
+
+5. Try out SciPy!
+
+        pixi run python
+
+See next steps in [the SciPy user guide][scipy-user-guide].
+
+<a name="environment-based"></a>
+
+## Environment-based workflows
+
+In environment-based workflows, you install packages into an environment, which you
+can activate and deactivate.
+These workflows are well-established,
+but lack some reproducibility benefits of project-based workflows.
+
+### Installing with `pip`
+
+1. [Install Python](https://www.python.org/downloads/).
+
+2. Create and activate a virtual environment with `venv`.
+
+    {{< admonition hint >}}
+    See [the tutorial in the Python Packaging User Guide][venv-guide].
+    {{< /admonition >}}
+
+[venv-guide]: https://packaging.python.org/en/latest/tutorials/installing-packages/#creating-virtual-environments
+
+3. Install SciPy, using [`pip`]:
+
+        python -m pip install scipy
+
+[`pip`]: https://pip.pypa.io/en/stable/getting-started/
+
+### Installing with `conda`
+
+[Miniforge] is the recommended way to install `conda` and [`mamba`],
+two Conda-based environment managers.
+You can then install SciPy from conda-forge as follows:
+
+    conda install scipy # or
+    mamba install scipy
+
+[Miniforge]: https://conda-forge.org/download/
+[`mamba`]: https://mamba.readthedocs.io/en/latest/
 
 <a name="system-package-managers"></a>
 
@@ -85,7 +156,7 @@ Pixi can also install packages from PyPI, using `uv` under the hood.
 System package managers can install the most common Python packages.
 They install packages for the entire computer, often use older versions,
 and don't have as many available versions. They are not the recommended
-installation method, but they are the simplest.
+installation method.
 
 ### Ubuntu and Debian
 
@@ -123,29 +194,17 @@ For details on how to build from source, see
 ## Installing with type stubs
 
 Static type stubs are available via a separate package, `scipy-stubs`, on
-PyPI and conda-forge. If you have already installed SciPy, you just need to
-install `scipy-stubs` in the same way:
-
-    python -m pip install scipy-stubs # or
-    uv add scipy-stubs # or
-    conda install scipy-stubs # or
-    pixi add scipy-stubs
-
-<!---
-XXX: https://github.com/conda-forge/scipy-stubs-feedstock/pull/5
--->
-
+PyPI and conda-forge.
 You can also install SciPy and `scipy-stubs` as a single package,
 via the `scipy-stubs[scipy]` extra on PyPI, or the `scipy-typed`
 package on conda-forge.
 To get a specific version `x.y.z` of SciPy (such as `1.14.1`),
-you should install version `x.y.z.*` below:
+you should install version `x.y.z.*`, for example:
 
-    python -m pip install "scipy-stubs[scipy]" # or
-    # versions for illustrative purposes
     uv add "scipy-stubs[scipy]==1.14.1.*" # or
-    conda install "scipy-typed>=1.14" # or
-    pixi add "scipy-typed=1.15.0.*"
+    pixi add "scipy-typed=1.15.0.*" # or
+    python -m pip install "scipy-stubs[scipy]" # or
+    conda install "scipy-typed>=1.14"
 
 Please direct questions about static typing support to
 [the `scipy-stubs` GitHub repository](https://github.com/jorenham/scipy-stubs).

--- a/content/en/install.md
+++ b/content/en/install.md
@@ -3,28 +3,38 @@ title: Installation
 sidebar: false
 ---
 
-Installations methods include:
+Installation methods include:
 
-- [Distributions](#distributions)
-- [pip](#pip-install)
-- [conda](#pip-install)
-- [Package Manager](#package_manager)
+- [Python Distributions](#distributions)
+- [PyPI (`pip`, `uv`)](#pypi-install)
+- [conda-forge (`conda`, `mamba`, `pixi`)](#conda-forge-install)
+- [System Package Managers](#system-package-manager)
 - [Source](#source)
 
 Methods differ in ease of use, coverage, maintenance of old versions,
-system-wide versus local environment use, and control. With pip or
-Anaconda\'s conda, you can control the package versions for a specific
+system-wide versus local environment use, and control. When installing
+from PyPI or with Conda, you can control the package versions for a specific
 project to prevent conflicts. Conda also controls non-Python packages,
 like MKL or HDF5. System package managers, like `apt-get`, install
-across the entire computer, often have older versions, and don\'t have
+across the entire computer, often have older versions, and don't have
 as many available versions. Source compilation is much more difficult
-but is necessary for debugging and development. If you don\'t know which
+but is necessary for debugging and development. If you don't know which
 installation method you need or prefer, we recommend the Scientific
 Python Distribution [Anaconda](https://www.anaconda.com/download/).
 
+Users in large, non-university institutions may want to read Anaconda's
+helpful blog on ["when is Anaconda free to use?"][anaconda-blog]
+
+[anaconda-blog]: https://www.anaconda.com/blog/update-on-anacondas-terms-of-service-for-academia-and-research
+
+To install SciPy with [static type stubs],
+see [Installing with type stubs](#type-stubs).
+
+[static type stubs]: https://typing.readthedocs.io/en/latest/guides/libraries.html
+
 <a name="distributions"></a>
 
-# Scientific Python Distributions (recommended)
+# Scientific Python Distributions (recommended for new users)
 
 Python distributions provide the language itself, along with the most
 commonly used packages and tools. These downloadable files require
@@ -36,11 +46,6 @@ and Linux, provides over 1,500 Python packages, and is used by over 15
 million people. Anaconda is best suited to beginning users; it provides
 a large collection of libraries all in one.
 
-For more advanced users who will need to install or upgrade regularly,
-[Mambaforge](https://github.com/conda-forge/miniforge#mambaforge) is a more
-suitable way to install the `conda` (and `mamba`, a faster `conda` alternative)
-package manager.
-
 Other options include:
 
 - [WinPython](https://winpython.github.io): Another free distribution
@@ -50,25 +55,81 @@ Other options include:
   and the IEP interactive development environment; Supports Linux,
   Windows, and Mac.
 
+If you already have Python installed, you can
+[install SciPy with `pip`](#pip-install).
+For more advanced users who will need to install or upgrade regularly,
+you may prefer to use a dedicated package manager like [`uv`]
+(see [Installing with `uv`](#uv-install])),
+[Conda], or [`pixi`] (see [Installing from conda-forge](#conda-forge-install)).
+
+[`uv`]: https://docs.astral.sh/uv/
+[Conda]: https://docs.conda.io/projects/conda/en/latest/index.html
+[`pixi`]: https://pixi.sh/latest/
+
+<a name="pypi-install"></a>
+
+# Installing from PyPI
+
+SciPy is [available on PyPI](PyPI-scipy), the Python Package Index.
+
+[PyPI-scipy]: https://pypi.org/project/scipy/
+
 <a name="pip-install"></a>
 
-# Installing with Pip
+## Installing with `pip`
 
 You can install SciPy from PyPI with `pip`:
 
-    python -m pip install scipy
+```bash
+python -m pip install scipy
+```
 
-<a name="conda-install"></a>
+<a name="uv-install"></a>
 
-# Installing via Conda
+## Installing with `uv`
 
-You can install SciPy from the `defaults` or `conda-forge` channels with `conda`:
+You can also add SciPy from PyPI to a `uv` project:
 
-    conda install scipy
+```bash
+uv add scipy
+```
 
-<a name="package_manager"></a>
+<a name="conda-forge-install"></a>
 
-# Install system-wide via a package manager
+# Installing from conda-forge
+
+## Installing with `conda` or `mamba`
+
+[`Miniforge`] is the recommended way to install the `conda`
+(and `mamba`, a faster `conda` alternative) package manager.
+You can then install SciPy as follows:
+
+```bash
+mamba install scipy
+```
+
+[`Miniforge`]: https://conda-forge.org/download/
+
+## Installing with `pixi`
+
+You can also add SciPy from conda-forge to a [`pixi`] project:
+
+```bash
+pixi add scipy
+```
+
+# Installing from the Anaconda Repository
+
+If you instead install `conda` via [`Miniconda`], you can install
+[SciPy from the Anaconda repository](https://anaconda.org/anaconda/scipy):
+
+```bash
+conda install scipy
+```
+
+<a name="system-package-manager"></a>
+
+# Install system-wide via a system package manager
 
 System package managers can install the most common Python packages.
 They install packages for the entire computer, often use older versions,
@@ -78,20 +139,26 @@ and don't have as many available versions.
 
 Using `apt-get`:
 
-    sudo apt-get install python3-scipy
+```bash
+sudo apt-get install python3-scipy
+```
 
 ## Fedora
 
 Using `dnf`:
 
-    sudo dnf install python3-scipy
+```bash
+sudo dnf install python3-scipy
+```
 
 ## macOS
 
 macOS doesn't have a preinstalled package manager, but you can install
 [Homebrew](https://brew.sh/) and use it to install SciPy (and Python itself):
 
-    brew install scipy
+```bash
+brew install scipy
+```
 
 <a name="source"></a>
 
@@ -101,3 +168,36 @@ A word of warning: building SciPy from source can be a nontrivial exercise. We
 recommend using binaries instead if those are available for your platform.
 For details on how to build from source, see
 [this guide in the SciPy docs](https://scipy.github.io/devdocs/building/index.html).
+
+<a name="type-stubs"></a>
+
+# Installing with type stubs
+
+Static type stubs are available via a separate package, `scipy-stubs`, on
+PyPI and conda-forge. If you have already installed SciPy, you just need to
+install `scipy-stubs` in the same way:
+
+```bash
+python -m pip install scipy-stubs # or
+uv add scipy-stubs # or
+mamba install scipy-stubs # or
+pixi add scipy-stubs
+```
+
+<!---
+XXX: https://github.com/conda-forge/scipy-stubs-feedstock/pull/5
+-->
+
+You can also install SciPy and `scipy-stubs` as a single package,
+via the `scipy-stubs[scipy]` extra on PyPI, or the `scipy-typed`
+package on conda-forge.
+To get a specific version `x.y.z` of SciPy (such as `1.14.1`),
+you should install version `x.y.z.*` below:
+
+```bash
+python -m pip install 'scipy-stubs[scipy]' # or
+# versions for illustrative purposes
+uv add 'scipy-stubs[scipy]==1.14.*' # or
+mamba install 'scipy-typed==1.14.1.*' # or
+pixi add 'scipy-typed==1.15.0.*'
+```

--- a/content/en/install.md
+++ b/content/en/install.md
@@ -59,7 +59,7 @@ If you already have Python installed, you can
 [install SciPy with `pip`](#pip-install).
 For more advanced users who will need to install or upgrade regularly,
 you may prefer to use a dedicated package manager like [`uv`]
-(see [Installing with `uv`](#uv-install])),
+(see [Installing with `uv`](#uv-install)),
 [Conda], or [`pixi`] (see [Installing from conda-forge](#conda-forge-install)).
 
 [`uv`]: https://docs.astral.sh/uv/

--- a/content/en/install.md
+++ b/content/en/install.md
@@ -121,9 +121,9 @@ but lack some reproducibility benefits of project-based workflows.
 
 ### Installing with `pip`
 
-1. [Install Python](https://www.python.org/downloads/).
+1.  [Install Python](https://www.python.org/downloads/).
 
-2. Create and activate a virtual environment with `venv`.
+2.  Create and activate a virtual environment with `venv`.
 
    {{< admonition hint >}}
 See [the tutorial in the Python Packaging User Guide](https://packaging.python.org/en/latest/tutorials/installing-packages/#creating-virtual-environments).

--- a/content/en/install.md
+++ b/content/en/install.md
@@ -78,9 +78,7 @@ SciPy is [available on PyPI](https://pypi.org/project/scipy/), the Python Packag
 
 You can install SciPy from PyPI with `pip`:
 
-```bash
-python -m pip install scipy
-```
+    python -m pip install scipy
 
 <a name="uv-install"></a>
 
@@ -88,9 +86,7 @@ python -m pip install scipy
 
 You can also add SciPy from PyPI to a `uv` project:
 
-```bash
-uv add scipy
-```
+    uv add scipy
 
 <a name="conda-forge-install"></a>
 
@@ -102,9 +98,7 @@ uv add scipy
 (and `mamba`, a faster `conda` alternative) package manager.
 You can then install SciPy as follows:
 
-```bash
-mamba install scipy
-```
+    mamba install scipy
 
 [`Miniforge`]: https://conda-forge.org/download/
 
@@ -112,18 +106,14 @@ mamba install scipy
 
 You can also add SciPy from conda-forge to a [`pixi`] project:
 
-```bash
-pixi add scipy
-```
+    pixi add scipy
 
 # Installing from the Anaconda Repository
 
 If you instead install `conda` via [`Miniconda`], you can install
 [SciPy from the Anaconda repository](https://anaconda.org/anaconda/scipy):
 
-```bash
-conda install scipy
-```
+    conda install scipy
 
 <a name="system-package-manager"></a>
 
@@ -137,26 +127,20 @@ and don't have as many available versions.
 
 Using `apt-get`:
 
-```bash
-sudo apt-get install python3-scipy
-```
+    sudo apt-get install python3-scipy
 
 ## Fedora
 
 Using `dnf`:
 
-```bash
-sudo dnf install python3-scipy
-```
+    sudo dnf install python3-scipy
 
 ## macOS
 
 macOS doesn't have a preinstalled package manager, but you can install
 [Homebrew](https://brew.sh/) and use it to install SciPy (and Python itself):
 
-```bash
-brew install scipy
-```
+    brew install scipy
 
 <a name="source"></a>
 
@@ -175,12 +159,10 @@ Static type stubs are available via a separate package, `scipy-stubs`, on
 PyPI and conda-forge. If you have already installed SciPy, you just need to
 install `scipy-stubs` in the same way:
 
-```bash
-python -m pip install scipy-stubs # or
-uv add scipy-stubs # or
-mamba install scipy-stubs # or
-pixi add scipy-stubs
-```
+    python -m pip install scipy-stubs # or
+    uv add scipy-stubs # or
+    mamba install scipy-stubs # or
+    pixi add scipy-stubs
 
 <!---
 XXX: https://github.com/conda-forge/scipy-stubs-feedstock/pull/5
@@ -192,10 +174,9 @@ package on conda-forge.
 To get a specific version `x.y.z` of SciPy (such as `1.14.1`),
 you should install version `x.y.z.*` below:
 
-```bash
-python -m pip install 'scipy-stubs[scipy]' # or
-# versions for illustrative purposes
-uv add 'scipy-stubs[scipy]==1.14.*' # or
-mamba install 'scipy-typed==1.14.1.*' # or
-pixi add 'scipy-typed==1.15.0.*'
-```
+    python -m pip install 'scipy-stubs[scipy]' # or
+    # versions for illustrative purposes
+    uv add 'scipy-stubs[scipy]==1.14.*' # or
+    mamba install 'scipy-typed==1.14.1.*' # or
+    pixi add 'scipy-typed==1.15.0.*'
+

--- a/content/en/install.md
+++ b/content/en/install.md
@@ -21,17 +21,13 @@ see [Installing with type stubs](#type-stubs).
 
 ## Project-based workflows
 
-In project-based workflows, a project is a directory containing a manifest
-file describing the project, a lock-file describing the exact dependencies
-of the project, and the project's (potentially multiple) environments.
-
 ### Installing with `uv`
 
 {{< admonition tip >}}
 If it is your first time installing a Python library, start here!
 {{< /admonition >}}
 
-Here is a step-by-step guide to setting up a project to try SciPy with [`uv`],
+Here is a step-by-step guide to setting up a project to try SciPy, with [`uv`],
 a Python package manager.
 
 [`uv`]: https://docs.astral.sh/uv/
@@ -49,19 +45,22 @@ a Python package manager.
 The second command changes directory into the directory of your project.
     {{< /admonition >}}
 
-3.  Install Python:
-
-        uv python install
-
-    {{< admonition note >}}
-If you have already installed Python, this step is optional.
-    {{< /admonition >}}
-
-4.  Add SciPy to your project:
+3.  Add SciPy to your project:
 
         uv add scipy
 
-5.  Try out SciPy!
+    {{< admonition note >}}
+This will automatically install Python if you don't already have it installed!
+    {{< /admonition >}}
+
+{{< admonition note >}}
+You can install other Python libraries in the same way, e.g.
+
+    uv add matplotlib
+
+{{< /admonition >}}
+
+4.  Try out SciPy!
 
         uv run python
 
@@ -100,10 +99,6 @@ tool [`pixi`] are very similar to the steps for `uv`:
 
         pixi add scipy
 
-    {{< admonition note >}}
-This step also adds Python from conda-forge.
-    {{< /admonition >}}
-
 4.  Try out SciPy!
 
         pixi run python
@@ -114,8 +109,13 @@ See next steps in [the SciPy user guide][scipy-user-guide].
 
 ## Environment-based workflows
 
-In environment-based workflows, you install packages into an environment, which you
-can activate and deactivate.
+In project-based workflows, a project is a directory containing a manifest
+file describing the project, a lock-file describing the exact dependencies
+of the project, and the project's (potentially multiple) environments.
+
+In contrast,
+in environment-based workflows you install packages into an environment,
+which you can activate and deactivate from any directory.
 These workflows are well-established,
 but lack some reproducibility benefits of project-based workflows.
 
@@ -125,9 +125,9 @@ but lack some reproducibility benefits of project-based workflows.
 
 2.  Create and activate a virtual environment with `venv`.
 
-   {{< admonition hint >}}
+    {{< admonition hint >}}
 See [the tutorial in the Python Packaging User Guide](https://packaging.python.org/en/latest/tutorials/installing-packages/#creating-virtual-environments).
-   {{< /admonition >}}
+    {{< /admonition >}}
 
 3.  Install SciPy, using [`pip`]:
 
@@ -139,7 +139,7 @@ See [the tutorial in the Python Packaging User Guide](https://packaging.python.o
 
 [Miniforge] is the recommended way to install `conda` and [`mamba`],
 two Conda-based environment managers.
-You can then install SciPy from conda-forge as follows:
+After creating an environment, you can install SciPy from conda-forge as follows:
 
     conda install scipy # or
     mamba install scipy


### PR DESCRIPTION
- Modernise discussion around installing from PyPI or conda-forge
- Include `uv` and `pixi` as options
- Add explanation of how to install with static type stubs
- remove mention of Python distributions and Anaconda `defaults` (https://github.com/scipy/scipy.org/pull/595#discussion_r1887539401)

cc @rgommers @stefanv @jarrodmillman @tupui @jorenham 