### PR TITLE
Change the Twitter icon to X

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -68,8 +68,8 @@ languages:
         socialmedia:
           - link: https://github.com/scipy/scipy
             icon: github
-          - link: https://twitter.com/SciPy_team
-            icon: twitter
+          - link: https://x.com/SciPy_team
+            icon: x-twitter
         quicklinks:
           column1:
             title: ""


### PR DESCRIPTION
We need to change the Twitter icon to X on the scipy.org webpage.

This is related to the PR in scipy: 
https://github.com/scipy/scipy/pull/22277