### PR TITLE
DOC: Update Fosstodon link for SciPy

### DIFF
--- a/content/en/about.md
+++ b/content/en/about.md
@@ -131,5 +131,5 @@ last updated in January 2022._
 
 ## Social Media
 
-- [@scipy on Mastodon](https://mastodon.social/@scipy@fosstodon.org)
+- [@scipy on Mastodon](https://fosstodon.org/@scipy)
 - [@SciPy_team on X](https://x.com/scipy_team)


### PR DESCRIPTION
Update Fosstodon link for SciPy. The correct link is:
<https://fosstodon.org/@scipy>

This is related to PR #602.