### PR TITLE
Add Discord invite link sentence

### DIFF
--- a/content/en/community.md
+++ b/content/en/community.md
@@ -56,6 +56,7 @@ in the community. To join, please [follow this invite link](https://join.slack.c
 ### [Scientific Python Discord](https://discord.com/invite/vur45CbwMz)
 
 You can also join the `#scipy` channel on the Scientific Python discord.
+To join, please [follow this invite link](https://discord.com/invite/vur45CbwMz).
 
 ### [StackOverflow](https://stackoverflow.com/questions/tagged/scipy)
 


### PR DESCRIPTION
This is a small documentation improvement proposal for the community document.

The original document mentions joining the #scipy channel on Discord, but it does not provide a link to join the Scientific Python Discord server.
While checking the Markdown file, we might notice that the title itself is a link to the Discord invitation. 
However, it would be better to include a clear explanation, similar to how to join the slack channel, to make it more user-friendly.
![image](https://github.com/user-attachments/assets/2b305ec1-640d-4c1f-ba89-b1946d3f3522)
