### PR TITLE
Update Japan SciPy conference name and link to current one.

### DIFF
--- a/content/en/community.md
+++ b/content/en/community.md
@@ -100,7 +100,7 @@ users are the SciPy and PyData conference series:
 - [EuroSciPy](https://www.euroscipy.org)
 - [SciPy Latin America](https://www.scipyla.org)
 - [SciPy India](https://scipy.in)
-- [SciPy Japan](https://conference.scipy.org)
+- [SciPyData (Japan)](https://scipydata.connpass.com/)
 - [PyData conferences](https://pydata.org/event-schedule/) (15-20 events a year spread over many countries)
 
 Many of these conferences include tutorial days that cover SciPy and/or sprints


### PR DESCRIPTION
In the current document, the link https://conference.scipy.org/ is used as the homepage for SciPy Japan. 
However, this link does not actually lead to the homepage of SciPy Japan.
Additionally, SciPy Japan has not been held since [2020](https://www.scipyjapan.scipy.org/). 
After confirming with Koyama san (@tkoyama010), one of the organizers, I confirmed that SciPy Japan has been integrated into the following conference:
SciPyData - connpass: https://scipydata.connpass.com/
Therefore, I believe this link should be used as the reference for the SciPy conference in Japan.