### PR TITLE
DOC: Add accent to the name İlhan Polat

### DIFF
--- a/content/en/about.md
+++ b/content/en/about.md
@@ -21,7 +21,7 @@ consists of the following members (in alphabetical order):
 - CJ Carey
 - Eric Larson
 - Evgeni Burovski
-- Ilhan Polat
+- İlhan Polat
 - Josef Perktold
 - Josh Wilson
 - Matt Haberland


### PR DESCRIPTION
In the `about.md` page: Add accent to the name `İ`lhan Polat with a dot on top of the "I".

In the BibTeX entry of `citing-scipy.md`, the name is written as `{\.I}`lhan Polat.