### PR TITLE
Announce SciPy 1.15.2

### DIFF
--- a/content/en/news.md
+++ b/content/en/news.md
@@ -1,9 +1,13 @@
 ---
 title: News
 sidebar: false
-newsHeader: SciPy 1.15.1 released!
-date: 2025-01-10
+newsHeader: SciPy 1.15.2 released!
+date: 2025-02-16
 ---
+
+### SciPy 1.15.2 released
+
+_February 16, 2025_ -- SciPy 1.15.2 has been released!
 
 ### SciPy 1.15.1 released
 
@@ -223,6 +227,7 @@ Here is a list of SciPy releases, with links to release notes. Bugfix
 releases (only the `z` changes in the `x.y.z` version number) have no new
 features; minor releases (the `y` increases) do.
 
+- SciPy 1.15.2 ([release notes](https://github.com/scipy/scipy/releases/tag/v1.15.2)) -- _2025-02-16_.
 - SciPy 1.15.1 ([release notes](https://github.com/scipy/scipy/releases/tag/v1.15.1)) -- _2025-01-10_.
 - SciPy 1.15.0 ([release notes](https://github.com/scipy/scipy/releases/tag/v1.15.0)) -- _2025-01-03_.
 - SciPy 1.14.1 ([release notes](https://github.com/scipy/scipy/releases/tag/v1.14.1)) -- _2024-08-20_.


### PR DESCRIPTION
Announce SciPy `1.15.2`.

The assets have been published on GitHub and PyPI; I'll deal with the final steps of the process tomorrow.