### PR TITLE
Announce SciPy 1.16.2

### DIFF
--- a/content/en/news.md
+++ b/content/en/news.md
@@ -1,9 +1,14 @@
 ---
 title: News
 sidebar: false
-newsHeader: SciPy 1.16.1 released!
-date: 2025-07-27
+newsHeader: SciPy 1.16.2 released!
+date: 2025-09-11
 ---
+
+### SciPy 1.16.2 released
+
+_September 11, 2025_ -- SciPy 1.16.2 has been released! This is the
+first stable release to provide Windows on ARM wheels on PyPI.
 
 ### SciPy 1.16.1 released
 
@@ -241,6 +246,7 @@ Here is a list of SciPy releases, with links to release notes. Bugfix
 releases (only the `z` changes in the `x.y.z` version number) have no new
 features; minor releases (the `y` increases) do.
 
+- SciPy 1.16.2 ([release notes](https://github.com/scipy/scipy/releases/tag/v1.16.2)) -- _2025-09-11_.
 - SciPy 1.16.1 ([release notes](https://github.com/scipy/scipy/releases/tag/v1.16.1)) -- _2025-07-27_.
 - SciPy 1.16.0 ([release notes](https://github.com/scipy/scipy/releases/tag/v1.16.0)) -- _2025-06-22_.
 - SciPy 1.15.3 ([release notes](https://github.com/scipy/scipy/releases/tag/v1.15.3)) -- _2025-05-08_.


### PR DESCRIPTION
Announce SciPy `1.16.2`, including a mention that this is the first stable release to provide "Windows on ARM" wheels on PyPI.