### PR TITLE
Fix scipy link in japanese language page

### DIFF
--- a/content/ja/_index.md
+++ b/content/ja/_index.md
@@ -43,7 +43,7 @@ SciPyの高いレベルで抽象化されたAPIは、どんな技術的バック
 type = 'card'
 title = 'オープンソース'
 body = '''
-SciPyは、様々な利用用途に寛容な[BSDライセンス](https://github.com/numpy/numpy/blob/main/LICENSE.txt)で公開されています。SciPyは活発で、互いを尊重し、多様性を認め合う[コミュニティ](/ja/community)によって、 [GitHub](https://github.com/numpy/numpy)上でオープンに開発されています。
+SciPyは、様々な利用用途に寛容な[BSDライセンス](https://github.com/scipy/scipy/blob/main/LICENSE.txt)で公開されています。SciPyは活発で、互いを尊重し、多様性を認め合う[コミュニティ](/ja/community)によって、 [GitHub](https://github.com/scipy/scipy)上でオープンに開発されています。
 '''
 
 {{< /grid >}}


### PR DESCRIPTION
This PR fixes the links to the SciPy repository and license on the [Japanese top page](https://scipy.org/ja/).

For some reason, the links on the Japanese top page were pointing to NumPy's repository.
Since the [English](https://github.com/scipy/scipy.org/blob/main/content/en/_index.md), [Spanish](https://github.com/scipy/scipy.org/blob/main/content/es/_index.md), and [Portuguese](https://github.com/scipy/scipy.org/blob/main/content/pt/_index.md) versions all link to SciPy's repository, this PR aligns the Japanese page with the others.