### PR TITLE
Announce SciPy 1.18.0

### DIFF
--- a/content/en/news.md
+++ b/content/en/news.md
@@ -1,9 +1,13 @@
 ---
 title: News
 sidebar: false
-newsHeader: SciPy 1.17.1 released!
-date: 2026-02-22
+newsHeader: SciPy 1.18.0 released!
+date: 2026-06-19
 ---
+
+### SciPy 1.18.0 released
+
+_June 19, 2026_ -- SciPy 1.18.0 has been released!
 
 ### SciPy 1.17.1 released
 
@@ -267,6 +271,7 @@ Here is a list of SciPy releases, with links to release notes. Bugfix
 releases (only the `z` changes in the `x.y.z` version number) have no new
 features; minor releases (the `y` increases) do.
 
+- SciPy 1.18.0 ([release notes](https://github.com/scipy/scipy/releases/tag/v1.18.0)) -- _2026-06-19_.
 - SciPy 1.17.1 ([release notes](https://github.com/scipy/scipy/releases/tag/v1.17.1)) -- _2026-02-22_.
 - SciPy 1.17.0 ([release notes](https://github.com/scipy/scipy/releases/tag/v1.17.0)) -- _2026-01-10_.
 - SciPy 1.16.3 ([release notes](https://github.com/scipy/scipy/releases/tag/v1.16.3)) -- _2025-10-28_.


### PR DESCRIPTION
Announce SciPy `1.18.0` following the release this morning.