### PR TITLE
Update to SPHT v0.23 release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ clean: ## remove the build artifacts, mainly the "public" directory
 	rm -rf $(HTMLDIR)
 
 prepare: clean
-	git submodule update --init
+	git submodule update --init --recursive
 	python gen_config.py
 
 # All translations share the <team>.toml files in the en translation

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ and served using [Hugo](https://gohugo.io).
 ## Build
 
 ```
-git submodule update --init
+git submodule update --init --recursive
 pixi run build
 ```
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [build.environment]
   PYTHON_VERSION = "3.13"
-  HUGO_VERSION = "0.152.2"
+  HUGO_VERSION = "0.158.0"
   DART_SASS_VERSION = "1.93.2"
   DART_SASS_URL = "https://github.com/sass/dart-sass/releases/download/"
 


### PR DESCRIPTION
Hi! This PR updates the website to use the v0.23 release of the Scientific Python Hugo Theme, which we've released today: https://github.com/scientific-python/scientific-python-hugo-theme/releases/tag/v0.23.